### PR TITLE
ErrBadConn to signal that the connection is in bad state

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -169,6 +169,9 @@ func (s *MssqlStmt) sendQuery(args []driver.Value) (err error) {
 	}
 	if len(args) == 0 {
 		if err = sendSqlBatch72(s.c.sess.buf, s.query, headers); err != nil {
+			if s.c.sess.tranid != 0 {
+				return err
+			}
 			return CheckBadConn(err)
 		}
 	} else {
@@ -192,6 +195,9 @@ func (s *MssqlStmt) sendQuery(args []driver.Value) (err error) {
 			return
 		}
 		if err = sendRpc(s.c.sess.buf, headers, Sp_ExecuteSql, 0, params); err != nil {
+			if s.c.sess.tranid != 0 {
+				return err
+			}
 			return CheckBadConn(err)
 		}
 	}


### PR DESCRIPTION
ErrBadConn is send only when there is a permanent network error and:
1) when Begin is called to begin a transaction,
or
2) when Exec/Query/QueryRow is called without an active transaction.
Upon receiving a ErrBadConn, the database/sql package, closes the connection and retries the Begin/Exec/etc in another connection.

@denisenkom please review
