### PR TITLE
Fix keepAlive parameter

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -665,7 +665,7 @@ func parseConnectParams(params map[string]string) (*connectParams, error) {
 		}
 		p.dial_timeout = time.Duration(timeout) * time.Second
 	}
-	keepAlive, ok := params["keepAlive"]
+	keepAlive, ok := params["keepalive"]
 	if ok {
 		timeout, err := strconv.ParseUint(keepAlive, 0, 16)
 		if err != nil {

--- a/tds_test.go
+++ b/tds_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 )
 
 type MockTransport struct {
@@ -319,5 +320,17 @@ func TestSecureConnection(t *testing.T) {
 	}
 	if !secure {
 		t.Fatal("connection is not encrypted")
+	}
+}
+
+func TestParseConnectParamsKeepAlive(t *testing.T) {
+	params := parseConnectionString("keepAlive=60")
+	parsedParams, err := parseConnectParams(params)
+	if err != nil {
+		t.Fatal("cannot parse params: ", err)
+	}
+
+	if parsedParams.keepAlive != time.Duration(60)*time.Second {
+		t.Fail()
 	}
 }


### PR DESCRIPTION
This fixes #87 where the `keepAlive` parameter was being ignored.