### PR TITLE
Add support for query notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Example:
   * false - Server certificate is checked. Default is false if encypt is specified.
   * true - Server certificate is not checked. Default is true if encrypt is not specified. If trust server certificate is true, driver accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks. This should be used only for testing.
 * "certificate" - The file that contains the public key certificate of the CA that signed the SQL Server certificate. The specified certificate overrides the go platform specific CA certificates.
-* "hostNameInCertificate" - Specifies the Common Name (CN) in the server certificate. Default value is the server host. 
+* "hostNameInCertificate" - Specifies the Common Name (CN) in the server certificate. Default value is the server host.
 * "ServerSPN" - The kerberos SPN (Service Principal Name) for the server. Default is MSSQLSvc/host:port.
 * "Workstation ID" - The workstation name (default is the host name)
 * "app name" - The application name (default is go-mssqldb)
@@ -70,6 +70,7 @@ where nnn represents an integer.
 * Supports encryption using SSL/TLS
 * Supports SQL Server and Windows Authentication
 * Supports Single-Sign-On on Windows
+* Supports query notifications
 
 ## Known Issues
 

--- a/mssql.go
+++ b/mssql.go
@@ -135,15 +135,30 @@ type MssqlStmt struct {
 	c          *MssqlConn
 	query      string
 	paramCount int
+	notifSub   *queryNotifSub
+}
+
+type queryNotifSub struct {
+	msgText string
+	options string
+	timeout uint32
 }
 
 func (c *MssqlConn) Prepare(query string) (driver.Stmt, error) {
 	q, paramCount := parseParams(query)
-	return &MssqlStmt{c, q, paramCount}, nil
+	return &MssqlStmt{c, q, paramCount, nil}, nil
 }
 
 func (s *MssqlStmt) Close() error {
 	return nil
+}
+
+func (s *MssqlStmt) SetQueryNotification(id, options string, timeout time.Duration) {
+	to := uint32(timeout / time.Second)
+	if to < 1 {
+		to = 1
+	}
+	s.notifSub = &queryNotifSub{id, options, to}
 }
 
 func (s *MssqlStmt) NumInput() int {
@@ -155,6 +170,12 @@ func (s *MssqlStmt) sendQuery(args []driver.Value) (err error) {
 		{hdrtype: dataStmHdrTransDescr,
 			data: transDescrHdr{s.c.sess.tranid, 1}.pack()},
 	}
+
+	if s.notifSub != nil {
+		headers = append(headers, headerStruct{hdrtype: dataStmHdrQueryNotif,
+			data: queryNotifHdr{s.notifSub.msgText, s.notifSub.options, s.notifSub.timeout}.pack()})
+	}
+
 	if len(args) != s.paramCount {
 		return errors.New(fmt.Sprintf("sql: expected %d parameters, got %d", s.paramCount, len(args)))
 	}

--- a/tds.go
+++ b/tds.go
@@ -516,6 +516,36 @@ const (
 	dataStmHdrTraceActivity = 3
 )
 
+// Query Notifications Header
+// http://msdn.microsoft.com/en-us/library/dd304949.aspx
+type queryNotifHdr struct {
+	notifyId      string
+	ssbDeployment string
+	notifyTimeout uint32
+}
+
+func (hdr queryNotifHdr) pack() (res []byte) {
+	notifyId := str2ucs2(hdr.notifyId)
+	ssbDeployment := str2ucs2(hdr.ssbDeployment)
+
+	res = make([]byte, 2+len(notifyId)+2+len(ssbDeployment)+4)
+	b := res
+
+	binary.LittleEndian.PutUint16(b, uint16(len(notifyId)))
+	b = b[2:]
+	copy(b, notifyId)
+	b = b[len(notifyId):]
+
+	binary.LittleEndian.PutUint16(b, uint16(len(ssbDeployment)))
+	b = b[2:]
+	copy(b, ssbDeployment)
+	b = b[len(ssbDeployment):]
+
+	binary.LittleEndian.PutUint32(b, hdr.notifyTimeout)
+
+	return res
+}
+
 // MARS Transaction Descriptor Header
 // http://msdn.microsoft.com/en-us/library/dd340515.aspx
 type transDescrHdr struct {


### PR DESCRIPTION
Added SetQueryNotification method to MssqlStmt. Parameter semantics are the same as in [`new SqlNotificationRequest(userData,options,timeout)`] (https://msdn.microsoft.com/en-us/library/kex3b5cy(v=vs.110).aspx).