### PR TITLE
Added `CheckBadConn` on the `Begin` method of a transaction.

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -89,7 +89,10 @@ func (c *MssqlConn) Begin() (driver.Tx, error) {
 	for tok := range tokchan {
 		switch token := tok.(type) {
 		case error:
-			return nil, token
+			if c.sess.tranid != 0 {
+				return nil, token
+			}
+			return nil, CheckBadConn(token)
 		}
 	}
 	// successful BEGINXACT request will return sess.tranid


### PR DESCRIPTION
As the transaction hasn't started yet it, we check to see if it is already in a transaction (if it is return a normal error), then that the error is either a timeout or a non-temporary network error, we should be safe to return `driver.ErrBadConn` at this point