### PR TITLE
Attempt all available IP addresses for host

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -740,12 +740,24 @@ func connect(params map[string]string) (res *tdsSession, err error) {
 	if err != nil {
 		return nil, err
 	}
-	addr := p.host + ":" + strconv.FormatUint(p.port, 10)
-	d := createDialer(p)
-	conn, err := d.Dial("tcp", addr)
+	ips, err := net.LookupIP(p.host)
 	if err != nil {
+		return nil, err
+	}
+	d := createDialer(p)
+	var conn net.Conn
+	for _, ip := range ips {
+		addr := fmt.Sprintf("%s:%d", ip, p.port)
+		conn, err = d.Dial("tcp", addr)
+		if err == nil {
+			break
+		}
+	}
+	if addr := fmt.Sprintf("%s:%d", p.host, p.port); err != nil {
 		f := "Unable to open tcp connection with host '%v': %v"
 		return nil, fmt.Errorf(f, addr, err.Error())
+	} else if conn == nil {
+		return nil, fmt.Errorf("Unable to open tcp connection with host '%v'", addr)
 	}
 
 	toconn := NewTimeoutConn(conn, p.conn_timeout)


### PR DESCRIPTION
The below MSDN article describes the correct behavior for AlwaysOn
Availability Groups, which is to try all IP addresses until a connection
request succeeds or until the connection requests time out.

https://msdn.microsoft.com/en-us/library/hh213417.aspx#AGlisteners

fixes #86