### PR TITLE
Fix connection string parsing

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -108,13 +108,13 @@ func parseConnectionString(dsn string) (res map[string]string) {
 			continue
 		}
 		lst := strings.SplitN(part, "=", 2)
-		name := strings.ToLower(lst[0])
+		name := strings.TrimSpace(strings.ToLower(lst[0]))
 		if len(name) == 0 {
 			continue
 		}
 		var value string = ""
 		if len(lst) > 1 {
-			value = lst[1]
+			value = strings.TrimSpace(lst[1])
 		}
 		res[name] = value
 	}


### PR DESCRIPTION
Previously, connection string parsing failing to trim extraneous whitespace surrounding either names or values.  Hence, if a connection string looked like this:

`"server=my_server; database=my_database; user id=me"`

Then the following key/value pairs would be put into the hash map:

`"server":"my_server"`
`" database":"my_database"`
`" user id":"me"`

Note the extra space in front of "database" and "user id".  This is a problem because the parseConnectionParams() function in tds.go tries to pull out key/value pairs by name.  For example, it does the following:

`p.database = params["database"]`

This will fail to pull out the " database" key that we put into the map, because it assumes that there is no leading or trailing whitespace around the key.

The single commit included in this pull request simply adds whitespace trimming for name and values parsed from connection strings, giving programmers more flexibility to format their connection strings with extra whitespace separators if they so desire.