### PR TITLE
try parsing host as IP if resolution fails

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -740,10 +740,18 @@ func connect(params map[string]string) (res *tdsSession, err error) {
 	if err != nil {
 		return nil, err
 	}
-	ips, err := net.LookupIP(p.host)
+
+	var ips []net.IP
+	ips, err = net.LookupIP(p.host)
 	if err != nil {
-		return nil, err
+		ip := net.ParseIP(p.host)
+		if ip == nil {
+			return nil, err
+		}
+
+		ips = []net.IP{ip}
 	}
+
 	d := createDialer(p)
 	var conn net.Conn
 	for _, ip := range ips {


### PR DESCRIPTION
When cross-compiling, net.LookupIP will use the built-in Go resolver,
which will not correctly resolve hosts values that are IPs. Handle this
case by checking whether the host is an IP if resolution fails.

Note that this looks like it will be handled by net.LookupIP in Go 1.5, but until then, this patch is needed to allow hosts to be specified as an IP address when using a cross-compiled binary.

More information can be found in
* https://groups.google.com/forum/#!topic/golang-nuts/nVqoIKHdZ6s/discussion.
* https://github.com/golang/go/issues/11335
* https://go-review.googlesource.com/#/c/11420/

This also fixes the issue discussed in #102.