### PR TITLE
add support for database mirroring sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Example:
 
 * "server" - host or host\instance (default localhost)
 * "port" - used only when there is no instance in server (default 1433)
+* "failoverpartner" - host or host\instance (default is no partner). Used only until a successful connection has been made; thereafter, the partner provided in the first successful connection is used.
+* "failoverport" - used only when there is no instance in failoverpartner (default 1433)
 * "user id" - enter the SQL Server Authentication user id or the Windows Authentication user id in the DOMAIN\User format. On Windows, if user id is empty or missing Single-Sign-On is used.
 * "password"
 * "database"

--- a/tds.go
+++ b/tds.go
@@ -115,6 +115,7 @@ type tdsSession struct {
 	buf      *tdsBuffer
 	loginAck loginAckStruct
 	database string
+	partner  string
 	columns  []columnStruct
 	tranid   uint64
 	logFlags uint64

--- a/token.go
+++ b/token.go
@@ -161,8 +161,8 @@ func processEnvChg(sess *tdsSession) {
 			}
 			sess.tranid = 0
 		case envDatabaseMirrorPartner:
-			// ignore envDatabaseMirrorPartner
-			_, err = readBVarChar(r)
+			sess.partner, err = readBVarChar(r)
+
 			if err != nil {
 				badStreamPanic(err)
 			}


### PR DESCRIPTION
Add support for database mirroring sessions.

Add two new connection string parameters, `failoverpartner` and `failoverport`. These new parameters are only used if a partner hasn't already been associated with the connection string.

Similarly to how the Microsoft drivers work, cache the partner of the first successful connection that provides a partner token. (see https://msdn.microsoft.com/en-us/library/ms175484.aspx#InitialConnection)

When a connection to the intial server fails, try the cached partner. If a partner has not yet been cached, use the `failoverpartner` and `failoverport` values.

The database mirror partner values provided in the ENVCHANGE token do not include port information, so append an instance name to the partner name before caching the partner so connecting to the partner will trigger service discovery.

This fixes the third scenario on #86.