### PR TITLE
Improve performance of str2ucs2

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1,7 +1,6 @@
 package mssql
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
@@ -297,13 +296,17 @@ type loginHeader struct {
 	SSPILongLength       uint32
 }
 
+// convert Go string to UTF-16 encoded []byte (littleEndian)
+// done manually rather than using bytes and binary packages
+// for performance reasons
 func str2ucs2(s string) []byte {
 	res := utf16.Encode([]rune(s))
-	buf := new(bytes.Buffer)
-	for _, item := range res {
-		binary.Write(buf, binary.LittleEndian, item)
+	ucs2 := make([]byte, 2*len(res))
+	for i := 0; i < len(res); i++ {
+		ucs2[2*i] = byte(res[i])
+		ucs2[2*i+1] = byte(res[i] >> 8)
 	}
-	return buf.Bytes()
+	return ucs2
 }
 
 func ucs22str(s []byte) (string, error) {


### PR DESCRIPTION
Hi,

Thanks so much for the work on this package, it's great!

When using it on an insert intensive workload, I noticed that the Go process was completely CPU bound.  Profiling, it looked like a major culprit was str2ucs2, transcoding the string parameters to UTF-16 for binding into the queries.  I only had a couple of VARCHAR columns (along with a couple dozen ints and datetimes) and they were only ten characters each, so this was pretty alarming.

As an experiment, I've re-implemented srt2ucs2 to essentially unroll the functionality from the bytes and encoding/binary packages.  This has substantially improved performance on my workload.  The process is no longer CPU bound and re-profiling and shown the CPU usage of str2ucs2 to be much lower. Inserts with more or bigger string parameters should see even greater improvement.

Regards,

-Mike