### PR TITLE
Support for ReadOnly connections to Availability Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Example:
 * "ServerSPN" - The kerberos SPN (Service Principal Name) for the server. Default is MSSQLSvc/host:port.
 * "Workstation ID" - The workstation name (default is the host name)
 * "app name" - The application name (default is go-mssqldb)
+* "ApplicationIntent" - Can be given the value "ReadOnly" to initiate a read-only connection to an Availability Group listener.
 
 Example:
 
@@ -72,6 +73,7 @@ where nnn represents an integer.
 * Supports encryption using SSL/TLS
 * Supports SQL Server and Windows Authentication
 * Supports Single-Sign-On on Windows
+* Supports connections to AlwaysOn Availability Group listeners, including re-direction to read-only replicas.
 
 ## Known Issues
 

--- a/mssql.go
+++ b/mssql.go
@@ -142,7 +142,7 @@ func (d *MssqlDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 func openConnection(dsn string, params map[string]string) (*MssqlConn, error) {
-	buf, err := connect(params)
+	sess, err := connect(params)
 	if err != nil {
 		partner := partnersCache.Get(dsn)
 		if partner == "" {
@@ -162,7 +162,7 @@ func openConnection(dsn string, params map[string]string) (*MssqlConn, error) {
 		return nil, err
 	}
 
-	if partner := buf.partner; partner != "" {
+	if partner := sess.partner; partner != "" {
 		// append an instance so the port will be ignored when this value is used;
 		// tds does not provide the port number.
 		if !strings.Contains(partner, `\`) {
@@ -171,7 +171,7 @@ func openConnection(dsn string, params map[string]string) (*MssqlConn, error) {
 		partnersCache.Set(dsn, partner)
 	}
 
-	return &MssqlConn{buf}, nil
+	return &MssqlConn{sess}, nil
 }
 
 func (c *MssqlConn) Close() error {

--- a/tds.go
+++ b/tds.go
@@ -229,6 +229,13 @@ const (
 	fIntSecurity   = 0x80
 )
 
+// TypeFlags
+const (
+	// 4 bits for fSQLType
+	// 1 bit for fOLEDB
+	fReadOnlyIntent = 32
+)
+
 type login struct {
 	TDSVersion     uint32
 	PacketSize     uint32
@@ -597,6 +604,7 @@ type connectParams struct {
 	serverSPN              string
 	workstation            string
 	appname                string
+	typeFlags              uint8
 }
 
 func parseConnectParams(params map[string]string) (*connectParams, error) {
@@ -731,6 +739,14 @@ func parseConnectParams(params map[string]string) (*connectParams, error) {
 		appname = "go-mssqldb"
 	}
 	p.appname = appname
+
+	appintent, ok := params["applicationintent"]
+	if ok {
+		if appintent == "ReadOnly" {
+			p.typeFlags |= fReadOnlyIntent
+		}
+	}
+
 	return &p, nil
 }
 
@@ -892,6 +908,7 @@ func connect(params map[string]string) (res *tdsSession, err error) {
 		HostName:     p.workstation,
 		ServerName:   p.host,
 		AppName:      p.appname,
+		TypeFlags:    p.typeFlags,
 	}
 	auth, auth_ok := getAuth(p.user, p.password, p.serverSPN, p.workstation)
 	if auth_ok {

--- a/tds.go
+++ b/tds.go
@@ -111,14 +111,16 @@ const (
 )
 
 type tdsSession struct {
-	buf      *tdsBuffer
-	loginAck loginAckStruct
-	database string
-	partner  string
-	columns  []columnStruct
-	tranid   uint64
-	logFlags uint64
-	log      *Logger
+	buf          *tdsBuffer
+	loginAck     loginAckStruct
+	database     string
+	partner      string
+	columns      []columnStruct
+	tranid       uint64
+	logFlags     uint64
+	log          *Logger
+	routedServer string
+	routedPort   uint16
 }
 
 const (
@@ -515,6 +517,18 @@ func readBVarByte(r io.Reader) (res []byte, err error) {
 	return
 }
 
+func readUshort(r io.Reader) (res uint16, err error) {
+	err = binary.Read(r, binary.LittleEndian, &res)
+	return
+}
+
+func readByte(r io.Reader) (res byte, err error) {
+	var b [1]byte
+	_, err = r.Read(b[:])
+	res = b[0]
+	return
+}
+
 // Packet Data Stream Headers
 // http://msdn.microsoft.com/en-us/library/dd304953.aspx
 type headerStruct struct {
@@ -756,15 +770,10 @@ type Auth interface {
 	Free()
 }
 
-func connect(params map[string]string) (res *tdsSession, err error) {
-	p, err := parseConnectParams(params)
-	if err != nil {
-		return nil, err
-	}
-
-	// SQL Server AlwaysOn Availability Group Listeners are bound by DNS to a
-	// list of IP addresses.  So if there is more than one, try them all and
-	// use the first one that allows a connection.
+// SQL Server AlwaysOn Availability Group Listeners are bound by DNS to a
+// list of IP addresses.  So if there is more than one, try them all and
+// use the first one that allows a connection.
+func dialConnection(p *connectParams) (conn net.Conn, err error) {
 	var ips []net.IP
 	ips, err = net.LookupIP(p.host)
 	if err != nil {
@@ -772,10 +781,8 @@ func connect(params map[string]string) (res *tdsSession, err error) {
 		if ip == nil {
 			return nil, err
 		}
-
 		ips = []net.IP{ip}
 	}
-	var conn net.Conn
 	if len(ips) == 1 {
 		d := createDialer(p)
 		addr := net.JoinHostPort(ips[0].String(), strconv.Itoa(int(p.port)))
@@ -820,6 +827,21 @@ func connect(params map[string]string) (res *tdsSession, err error) {
 	if err != nil {
 		f := "Unable to open tcp connection with host '%v:%v': %v"
 		return nil, fmt.Errorf(f, p.host, p.port, err.Error())
+	}
+
+	return conn, err
+}
+
+func connect(params map[string]string) (res *tdsSession, err error) {
+	p, err := parseConnectParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+initiate_connection:
+	conn, err := dialConnection(p)
+	if err != nil {
+		return nil, err
 	}
 
 	toconn := NewTimeoutConn(conn, p.conn_timeout)
@@ -962,6 +984,12 @@ continue_login:
 	}
 	if !success {
 		return nil, fmt.Errorf("Login failed")
+	}
+	if sess.routedServer != "" {
+		toconn.Close()
+		p.host = sess.routedServer
+		p.port = uint64(sess.routedPort)
+		goto initiate_connection
 	}
 	return &sess, nil
 }


### PR DESCRIPTION
OK, I've taken a crack at this as discussed in issue #127.  I've tested it in all the ways that I can with our database infrastructure and it seems to work fine.

Apologies in advance for the use of another `goto` but it seemed like the best way to implement the connection state logic without a major refactoring.

Please let me know if there are any suggestions for improvements.