### PR TITLE
Fix potential race condition bug

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -824,7 +824,8 @@ func dialConnection(p *connectParams) (conn net.Conn, err error) {
 			}
 		}
 	}
-	if err != nil {
+	// Can't do the usual err != nil check, as it is possible to have gotten an error before a successful connection
+	if conn == nil {
 		f := "Unable to open tcp connection with host '%v:%v': %v"
 		return nil, fmt.Errorf(f, p.host, p.port, err.Error())
 	}


### PR DESCRIPTION
While re-using this code in another application I realised that there is a potential bug.  It might be possible for one IP address to return an error before another one returns a successful connection, in which case the error handling code would have caused the connection to be ignored.  This never happened to occur in the availability group because the non-primary listeners would take a while to time out.  Don't want to depend on that, though.