### PR TITLE
Remove any accumulated errors, otherwise Open will assume we've failed

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -819,6 +819,8 @@ func dialConnection(p *connectParams) (conn net.Conn, err error) {
 						}
 					}
 				}(len(ips) - i - 1)
+				// Remove any earlier errors we may have collected
+				err = nil
 				break wait_loop
 			case err = <-errChan:
 			}


### PR DESCRIPTION
There was a race condition in the dialConnection with multiple machines. If we received an error before we received a connection we would return both a connection and an error. The calling code in mssql.go would then assume we'd failed based on the presence of the error. This change nils out the error if we've obtained a successful connection.