### PR TITLE
return driver.ErrBadConn on all net.Error values

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -33,11 +33,13 @@ func CheckBadConn(err error) error {
 	if err == io.EOF {
 		return driver.ErrBadConn
 	}
-	neterr, ok := err.(net.Error)
-	if !ok || (!neterr.Timeout() && neterr.Temporary()) {
+
+	switch err.(type) {
+	case net.Error:
+		return driver.ErrBadConn
+	default:
 		return err
 	}
-	return driver.ErrBadConn
 }
 
 type MssqlConn struct {
@@ -289,7 +291,7 @@ loop:
 		// set nocount on; select 1
 		// see TestIgnoreEmptyResults test
 		//case doneStruct:
-			//break loop
+		//break loop
 		case []columnStruct:
 			cols = make([]string, len(token))
 			for i, col := range token {

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -1,0 +1,52 @@
+package mssql
+
+import (
+	"database/sql/driver"
+	"errors"
+	"io"
+	"testing"
+)
+
+type netError struct{}
+
+func (e netError) Timeout() bool {
+	return true
+}
+
+func (e netError) Temporary() bool {
+	return true
+}
+
+func (e netError) Error() string {
+	return "dummy network error"
+}
+
+func TestCheckBadConn(t *testing.T) {
+	err := errors.New("not a network error")
+	tests := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{
+			name:     "network error",
+			err:      netError{},
+			expected: driver.ErrBadConn,
+		}, {
+			name:     "EOF",
+			err:      io.EOF,
+			expected: driver.ErrBadConn,
+		}, {
+			name:     "not an I/O error",
+			err:      err,
+			expected: err,
+		},
+	}
+
+	for _, tt := range tests {
+		actual := CheckBadConn(tt.err)
+		if actual != tt.expected {
+			t.Error("%s: unexpected error.", tt.name)
+		}
+	}
+}


### PR DESCRIPTION
Fixes running queries against a sql server that is restarted after
calling db.Open.

Previously, opening a connection and successfully executing queries followed by restarting SQL Server would cause all future queries to fail, because the error would be a `net.OpError` where `Temporary()` returns true and `Timeout()` returns false. Assuming this code scenario used to work as expected, I suspect that the change introduced in https://github.com/golang/go/commit/055ecb7be5805e07498488c59c6f01644fdacccc#diff-ae34eb42831ffecf011ea43c6429582c may have been the root cause of this change in behavior.