### PR TITLE
Prevent panic to do with unknown env type change with Azure SQL v12

### DIFF
--- a/token.go
+++ b/token.go
@@ -206,7 +206,7 @@ func processEnvChg(sess *tdsSession) {
 			}
 			_, err = readBVarByte(r)
 			if err != nil {
-				badStreamPanic(err)
+				continue
 			}
 		}
 

--- a/token.go
+++ b/token.go
@@ -204,10 +204,7 @@ func processEnvChg(sess *tdsSession) {
 			if err != nil {
 				badStreamPanic(err)
 			}
-			_, err = readBVarByte(r)
-			if err != nil {
-				continue
-			}
+			readBVarByte(r)
 		}
 
 	}


### PR DESCRIPTION
A previous commit ignores unknown env type changes (7e2729fe645bb216b0a23f80af5b6fd5b5bc35bf), but it can still panic with unexpected EOF. This commit ignore such errors. Applying it resolves #103 for me.
