### PR TITLE
Add SQLError... methods to Error type

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 )
 
+// Error represents an SQL Server error. This
+// type includes methods for reading the contents
+// of the struct, which allows calling programs
+// to check for specific error conditions without
+// having to import this package directly.
 type Error struct {
 	Number     int32
 	State      uint8
@@ -16,6 +21,35 @@ type Error struct {
 
 func (e Error) Error() string {
 	return "mssql: " + e.Message
+}
+
+// SQLErrorNumber returns the SQL Server error number.
+func (e Error) SQLErrorNumber() int32 {
+	return e.Number
+}
+
+func (e Error) SQLErrorState() uint8 {
+	return e.State
+}
+
+func (e Error) SQLErrorClass() uint8 {
+	return e.Class
+}
+
+func (e Error) SQLErrorMessage() string {
+	return e.Message
+}
+
+func (e Error) SQLErrorServerName() string {
+	return e.ServerName
+}
+
+func (e Error) SQLErrorProcName() string {
+	return e.ProcName
+}
+
+func (e Error) SQLErrorLineNo() int32 {
+	return e.LineNo
 }
 
 type StreamError struct {

--- a/error_example_test.go
+++ b/error_example_test.go
@@ -1,0 +1,38 @@
+package mssql
+
+import "fmt"
+
+func ExampleError_1() {
+	// call a function that might return a mssql error
+	err := callUsingMSSQL()
+
+	type ErrorWithNumber interface {
+		SQLErrorNumber() int32
+	}
+
+	if errorWithNumber, ok := err.(ErrorWithNumber); ok {
+		if errorWithNumber.SQLErrorNumber() == 1205 {
+			fmt.Println("deadlock error")
+		}
+	}
+}
+
+func ExampleError_2() {
+	// call a function that might return a mssql error
+	err := callUsingMSSQL()
+
+	type SQLError interface {
+		SQLErrorNumber() int32
+		SQLErrorMessage() string
+	}
+
+	if sqlError, ok := err.(SQLError); ok {
+		if sqlError.SQLErrorNumber() == 1205 {
+			fmt.Println("deadlock error", sqlError.SQLErrorMessage())
+		}
+	}
+}
+
+func callUsingMSSQL() error {
+	return nil
+}


### PR DESCRIPTION
Sometimes it is handy to be able to check details of the error returned from SQL server. Examples of error conditions that may warrant special handling include:
- Deadlock
- Duplicate key in unique index
- Timeout

There may be more.

Although it is possible to attempt to cast a returned error to the `mssql.Error` type, this requires importing the package in the code. While this is not a problem in many cases, it can be a problem with code that is designed to work with a number of different database backends.

A simpler approach to error handling is to provide methods on the `Error` type that will return information. A calling program can then attempt to cast the error type to a local interface type.

This example shows how a calling program can check for a SQL Server deadlock error without having to import the `mssqldb` package.

``` go
func Example() {
        // call a function that might return a mssql error
        err := callUsingMSSQL()

        type SQLError interface {
                SQLErrorNumber() int32
        }

        if sqlError, ok := err.(SQLError); ok {
                if sqlError.SQLErrorNumber() == 1205 {
                        // special handling for deadlock error goes here
                        fmt.Println("deadlock error")
                }
        }
}
```
