### PR TITLE
Allow leading/trailing space and semicolon in user id and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Example:
     db, err := sql.Open("mssql", "server=localhost;user id=sa")
 ```
 
+Note: <tab> may be used instead of `;` as a separator, in which case user ids and passwords with leading/trailing spaces and semicolons are preserved:
+
+```go
+   db, err := sql.Open("mssql", "server=localhost\tuser id= sa \tpassword=12345;54321")
+   // user id: ' sa '
+   // password: '12345;54321'
+```
+
 ## Statement Parameters
 
 In the SQL statement text, literals may be replaced by a parameter that matches one of the following:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Example:
     db, err := sql.Open("mssql", "server=localhost;user id=sa")
 ```
 
-Note: <tab> may be used instead of `;` as a separator, in which case user ids and passwords with leading/trailing spaces and semicolons are preserved:
+Note: `<tab>` may be used instead of `;` as a separator, in which case user ids and passwords with leading/trailing spaces and semicolons are preserved:
 
 ```go
    db, err := sql.Open("mssql", "server=localhost\tuser id= sa \tpassword=12345;54321")

--- a/mssql.go
+++ b/mssql.go
@@ -109,6 +109,9 @@ func (c *MssqlConn) Begin() (driver.Tx, error) {
 
 func parseConnectionString(dsn string) (res map[string]string) {
 	res = map[string]string{}
+	if strings.Contains(dsn, "\t") {
+		return parseConnectionStringV2(dsn)
+	}
 	parts := strings.Split(dsn, ";")
 	for _, part := range parts {
 		if len(part) == 0 {
@@ -125,6 +128,33 @@ func parseConnectionString(dsn string) (res map[string]string) {
 		}
 		res[name] = value
 	}
+
+	return res
+}
+
+func parseConnectionStringV2(dsn string) (res map[string]string) {
+	res = map[string]string{}
+	parts := strings.Split(dsn, "\t")
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		lst := strings.SplitN(part, "=", 2)
+		name := strings.TrimSpace(strings.ToLower(lst[0]))
+		if len(name) == 0 {
+			continue
+		}
+		var value string = ""
+		if len(lst) > 1 {
+			if name != "user id" && name != "password" {
+				value = strings.TrimSpace(lst[1])
+			} else {
+				value = lst[1]
+			}
+		}
+		res[name] = value
+	}
+
 	return res
 }
 

--- a/mssql.go
+++ b/mssql.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	USER_ID_KEY  = "user_id"
+	USER_ID_KEY  = "user id"
 	PASSWORD_KEY = "password"
 )
 

--- a/mssql.go
+++ b/mssql.go
@@ -14,6 +14,11 @@ import (
 	"time"
 )
 
+const (
+	USER_ID_KEY  = "user_id"
+	PASSWORD_KEY = "password"
+)
+
 func init() {
 	sql.Register("mssql", &MssqlDriver{})
 }
@@ -146,7 +151,7 @@ func parseConnectionStringV2(dsn string) (res map[string]string) {
 		}
 		var value string = ""
 		if len(lst) > 1 {
-			if name != "user id" && name != "password" {
+			if name != USER_ID_KEY && name != PASSWORD_KEY {
 				value = strings.TrimSpace(lst[1])
 			} else {
 				value = lst[1]

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -162,3 +162,28 @@ func TestParseConnectionStringUserIdHasTrailingSpace(t *testing.T) {
 		t.Error("parseConnectionString; result key 'user id'; key is missing")
 	}
 }
+
+func TestParseConnectionStringPasswordHasCamelCaseKeyAndTrailingSpace(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tuser id=bar\tPassWord=baz \tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["password"]; ok {
+		if val != "baz " {
+			t.Errorf("parseConnectionString; result key 'password'; expected 'baz ', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'password'; key is missing")
+	}
+}
+
+func TestParseConnectionStringUserIdHasCamelCaseKeyAndTrailingSpace(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tUser ID=bar \tpassword=baz\tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["user id"]; ok {
+		if val != "bar " {
+			t.Errorf("parseConnectionString; result key 'user id'; expected 'bar ', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'user id'; key is missing")
+	}
+}
+

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -126,3 +126,39 @@ func TestParseConnectionStringPasswordHasTrailingSpace(t *testing.T) {
 		t.Error("parseConnectionString; result key 'password'; key is missing")
 	}
 }
+
+func TestParseConnectionStringUserIdHasSemicolon(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tuser id=bar;\tpassword=baz\tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["user id"]; ok {
+		if val != "bar;" {
+			t.Errorf("parseConnectionString; result key 'user id'; expected 'bar;', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'user id'; key is missing")
+	}
+}
+
+func TestParseConnectionStringUserIdHasLeadingSpace(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tuser id= bar\tpassword=baz\tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["user id"]; ok {
+		if val != " bar" {
+			t.Errorf("parseConnectionString; result key 'user id'; expected ' bar', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'user id'; key is missing")
+	}
+}
+
+func TestParseConnectionStringUserIdHasTrailingSpace(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tuser id=bar \tpassword=baz\tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["user id"]; ok {
+		if val != "bar " {
+			t.Errorf("parseConnectionString; result key 'user id'; expected 'bar ', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'user id'; key is missing")
+	}
+}

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -50,3 +50,79 @@ func TestCheckBadConn(t *testing.T) {
 		}
 	}
 }
+
+func TestParseConnectionStringHappyCase(t *testing.T) {
+
+	res := parseConnectionString("server=foo;user id=bar;password=baz;encrypt=true;TrustServerCertificate=true")
+	if val, ok := res["server"]; ok {
+		if val != "foo" {
+			t.Errorf("parseConnectionString; result key 'server'; expected 'foo', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'server'; key is missing")
+	}
+	if val, ok := res["user id"]; ok {
+		if val != "bar" {
+			t.Errorf("parseConnectionString; result key 'user id'; expected 'bar', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'user id'; key is missing")
+	}
+	if val, ok := res["password"]; ok {
+		if val != "baz" {
+			t.Errorf("parseConnectionString; result key 'password'; expected 'baz', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'password'; key is missing")
+	}
+	if val, ok := res["encrypt"]; ok {
+		if val != "true" {
+			t.Errorf("parseConnectionString; result key 'encrypt'; expected 'true', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'encrypt'; key is missing")
+	}
+	if val, ok := res["trustservercertificate"]; ok {
+		if val != "true" {
+			t.Errorf("parseConnectionString; result key 'TrustServerCertificate'; expected 'true', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'TrustServerCertificate'; key is missing")
+	}
+}
+
+func TestParseConnectionStringPasswordHasSemicolon(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tuser id=bar\tpassword=baz;\tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["password"]; ok {
+		if val != "baz;" {
+			t.Errorf("parseConnectionString; result key 'password'; expected 'baz;', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'password'; key is missing")
+	}
+}
+
+func TestParseConnectionStringPasswordHasLeadingSpace(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tuser id=bar\tpassword= baz\tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["password"]; ok {
+		if val != " baz" {
+			t.Errorf("parseConnectionString; result key 'password'; expected ' baz', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'password'; key is missing")
+	}
+}
+
+func TestParseConnectionStringPasswordHasTrailingSpace(t *testing.T) {
+
+	res := parseConnectionString("server=foo\tuser id=bar\tpassword=baz \tencrypt=true\tTrustServerCertificate=true")
+	if val, ok := res["password"]; ok {
+		if val != "baz " {
+			t.Errorf("parseConnectionString; result key 'password'; expected 'baz ', got '%s'", val)
+		}
+	} else {
+		t.Error("parseConnectionString; result key 'password'; key is missing")
+	}
+}


### PR DESCRIPTION
Fix for issue #169 
- Examine the connection string; if a `<tab>` is present, parse using the `<tab>` as the separator, and ensure that 'user id' and 'password' values are not trimmed.
- Updated README
