### PR TITLE
added a check to net.Error.Timeout() before returning driver.ErrBadConn

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -31,8 +31,11 @@ func CheckBadConn(err error) error {
 		return driver.ErrBadConn
 	}
 
-	switch err.(type) {
+	switch e := err.(type) {
 	case net.Error:
+		if e.Timeout() {
+			return errors.New("driver: connection timeout")
+		}
 		return driver.ErrBadConn
 	default:
 		return err


### PR DESCRIPTION
I believe this doesn't necessary close #134 or #105 but I think it will help troubleshoot in the future and addresses problems that were brought up in both issue threads.

net.Error has a method .Timeout() that returns a bool if the error was because of an expired timeout. I added a check before the return of the driver.ErrBadConn.
