### PR TITLE
Use interface for logging

### DIFF
--- a/log.go
+++ b/log.go
@@ -4,19 +4,26 @@ import (
 	"log"
 )
 
-type Logger log.Logger
+type Logger interface {
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}
 
-func (logger *Logger) Printf(format string, v ...interface{}) {
-	if logger != nil {
-		(*log.Logger)(logger).Printf(format, v...)
+type optionalLogger struct {
+	logger Logger
+}
+
+func (o optionalLogger) Printf(format string, v ...interface{}) {
+	if o.logger != nil {
+		o.logger.Printf(format, v...)
 	} else {
 		log.Printf(format, v...)
 	}
 }
 
-func (logger *Logger) Println(v ...interface{}) {
-	if logger != nil {
-		(*log.Logger)(logger).Println(v...)
+func (o optionalLogger) Println(v ...interface{}) {
+	if o.logger != nil {
+		o.logger.Println(v...)
 	} else {
 		log.Println(v...)
 	}

--- a/mssql.go
+++ b/mssql.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"net"
 	"strings"
@@ -20,11 +19,11 @@ func init() {
 }
 
 type MssqlDriver struct {
-	log *log.Logger
+	log optionalLogger
 }
 
-func (d *MssqlDriver) SetLogger(logger *log.Logger) {
-	d.log = logger
+func (d *MssqlDriver) SetLogger(logger Logger) {
+	d.log = optionalLogger{logger}
 }
 
 func CheckBadConn(err error) error {
@@ -137,7 +136,7 @@ func (d *MssqlDriver) Open(dsn string) (driver.Conn, error) {
 	}
 
 	conn := &MssqlConn{sess}
-	conn.sess.log = (*Logger)(d.log)
+	conn.sess.log = d.log
 	return conn, nil
 }
 

--- a/tds.go
+++ b/tds.go
@@ -119,7 +119,7 @@ type tdsSession struct {
 	columns      []columnStruct
 	tranid       uint64
 	logFlags     uint64
-	log          *Logger
+	log          optionalLogger
 	routedServer string
 	routedPort   uint16
 }


### PR DESCRIPTION
Previously the driver would only accept setting the logger to stdlib
*log.Logger structs. This change allows anything with a logger-like
interface to be used instead.

In order to make logging work even when a logger isn't explicitly
specified, an optionalLogger struct has been added that still works (by
logging to the global stdlib logger) as its zero value. It fills the
same function as the Logger struct it's replacing, though the naming
makes things a little more obvious.

Another option I explored was just using the new Logger interface
directly as the type of log in MssqlDriver. We could provide a default
struct that implements Logger and just forwards to the global stdlib log
functions

The problem was that this default needed to be provided everywhere a
MssqlDriver is created. Since log is private, that meant that no one
outside of the package could ever create an instance of the public
MssqlDriver that would actually work. Honestly I don't know that they
ever _would_, or whether it could be alleviated by providing a public
constructor, but in the interest of keeping things compatible I opted
for the optionalLogger strategy I outlined above.