### PR TITLE
Sum rows affected for multi-statement Exec calls.

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -341,11 +341,11 @@ func (s *MssqlStmt) processExec(ctx context.Context) (res driver.Result, err err
 		switch token := token.(type) {
 		case doneInProcStruct:
 			if token.Status&doneCount != 0 {
-				rowCount = int64(token.RowCount)
+				rowCount += int64(token.RowCount)
 			}
 		case doneStruct:
 			if token.Status&doneCount != 0 {
-				rowCount = int64(token.RowCount)
+				rowCount += int64(token.RowCount)
 			}
 			if token.isError() {
 				return nil, token.getError()


### PR DESCRIPTION
When a given Exec call contains multiple SQL statement, we should sum the number of rows affected from all the statements executed rather than using the number of rows affected from the last statement, e.g.

```
UPDATE Timer SET unit = 1 WHERE id = 1234 # no rows affect if the row doesn't exit, otherwise 1 row affected

INSERT INTO Timer (id, unit)
SELECT 1234, 1
   FROM Timers
 WHERE @@rowcount = 0 # if the above statement affects rows, this will return no rows affected
```

By summing all the rows affected in the Go code, you get the count of what happened.