### PR TITLE
add UniqueIdentifier type

### DIFF
--- a/queries_test.go
+++ b/queries_test.go
@@ -684,7 +684,7 @@ func TestUniqueIdentifierParam(t *testing.T) {
 				t.Fatal("select / scan failed", err.Error())
 			}
 
-			if !expected.Equal(uuid2) {
+			if expected != uuid2 {
 				t.Errorf("uniqueidentifier does not match: '%s' '%s'", expected, uuid2)
 			}
 		})

--- a/queries_test.go
+++ b/queries_test.go
@@ -650,6 +650,47 @@ func TestDateTimeParam(t *testing.T) {
 
 }
 
+func TestUniqueIdentifierParam(t *testing.T) {
+	conn := open(t)
+	defer conn.Close()
+	type testStruct struct {
+		name string
+		uuid interface{}
+	}
+
+	expected := UniqueIdentifier{0x01, 0x23, 0x45, 0x67,
+		0x89, 0xAB,
+		0xCD, 0xEF,
+		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+	}
+
+	values := []testStruct{
+		{
+			"[]byte",
+			[]byte{0x67, 0x45, 0x23, 0x01,
+				0xAB, 0x89,
+				0xEF, 0xCD,
+				0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}},
+		{
+			"string",
+			"01234567-89ab-cdef-0123-456789abcdef"},
+	}
+
+	for _, test := range values {
+		t.Run(test.name, func(t *testing.T) {
+			var uuid2 UniqueIdentifier
+			err := conn.QueryRow("select ?", test.uuid).Scan(&uuid2)
+			if err != nil {
+				t.Fatal("select / scan failed", err.Error())
+			}
+
+			if !expected.Equal(uuid2) {
+				t.Errorf("uniqueidentifier does not match: '%s' '%s'", expected, uuid2)
+			}
+		})
+	}
+}
+
 func TestBigQuery(t *testing.T) {
 	conn := open(t)
 	defer conn.Close()

--- a/types.go
+++ b/types.go
@@ -134,10 +134,11 @@ func writeVarLen(w io.Writer, ti *typeInfo) (err error) {
 			return
 		}
 		ti.Writer = writeByteLenType
-	case typeGuid, typeIntN, typeDecimal, typeNumeric,
+	case typeIntN, typeDecimal, typeNumeric,
 		typeBitN, typeDecimalN, typeNumericN, typeFltN,
 		typeMoneyN, typeDateTimeN, typeChar,
 		typeVarChar, typeBinary, typeVarBinary:
+
 		// byle len types
 		if ti.Size > 0xff {
 			panic("Invalid size for BYLELEN_TYPE")
@@ -155,6 +156,14 @@ func writeVarLen(w io.Writer, ti *typeInfo) (err error) {
 			if err != nil {
 				return
 			}
+		}
+		ti.Writer = writeByteLenType
+	case typeGuid:
+		if !(ti.Size == 0x10 || ti.Size == 0x00) {
+			panic("Invalid size for BYLELEN_TYPE")
+		}
+		if err = binary.Write(w, binary.LittleEndian, uint8(ti.Size)); err != nil {
+			return
 		}
 		ti.Writer = writeByteLenType
 	case typeBigVarBin, typeBigVarChar, typeBigBinary, typeBigChar,

--- a/uniqueidentifier.go
+++ b/uniqueidentifier.go
@@ -1,0 +1,91 @@
+package mssql
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+var nilUUID = make([]byte, 16) // RFC 4122 section 4.1.7 says a nil UUID is all zeros.
+
+type UniqueIdentifier []byte
+
+func (u *UniqueIdentifier) Scan(v interface{}) error {
+	reverse := func(b []byte) {
+		for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+			b[i], b[j] = b[j], b[i]
+		}
+	}
+
+	switch vt := v.(type) {
+	case []byte:
+		if len(vt) != 16 {
+			return errors.New("mssql: invalid UniqueIdentifier length")
+		}
+
+		raw := make(UniqueIdentifier, 16)
+
+		copy(raw, vt)
+
+		reverse(raw[0:4])
+		reverse(raw[4:6])
+		reverse(raw[6:8])
+		*u = raw
+
+		return nil
+	case string:
+		if len(vt) != 36 {
+			return errors.New("mssql: invalid UniqueIdentifier string length")
+		}
+
+		b := []byte(vt)
+		for i, c := range b {
+			switch c {
+			case '-':
+				b = append(b[:i], b[i+1:]...)
+			}
+		}
+
+		*u = make(UniqueIdentifier, 16)
+		_, err := hex.Decode(*u, []byte(b))
+		return err
+	default:
+		return fmt.Errorf("mssql: cannot convert %T to UniqueIdentifier", v)
+	}
+}
+
+func (u UniqueIdentifier) Value() (driver.Value, error) {
+	reverse := func(b []byte) {
+		for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+			b[i], b[j] = b[j], b[i]
+		}
+	}
+
+	if len([]byte(u)) != 16 {
+		return nil, errors.New("mssql: invalid UniqueIdentifier length")
+	}
+
+	raw := make([]byte, 16)
+
+	copy(raw, u)
+
+	reverse(raw[0:4])
+	reverse(raw[4:6])
+	reverse(raw[6:8])
+
+	return raw, nil
+}
+
+func (u UniqueIdentifier) String() string {
+	b := []byte(u)
+	if len(b) != 16 {
+		b = nilUUID
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+func (u UniqueIdentifier) Equal(u2 UniqueIdentifier) bool {
+	return bytes.Equal(u, u2)
+}

--- a/uniqueidentifier_test.go
+++ b/uniqueidentifier_test.go
@@ -65,29 +65,6 @@ func TestUniqueIdentifierString(t *testing.T) {
 	}
 }
 
-func TestUniqueIdentifierImplementsStringer(t *testing.T) {
-	var v interface{}
-	v = new(UniqueIdentifier)
-
-	if _, ok := v.(fmt.Stringer); !ok {
-		t.Error(`Uniqueidentifier must be fmt.Stringer`)
-	}
-
-}
-func TestUniqueIdentifierImplementsScanner(t *testing.T) {
-	var v interface{}
-	v = new(UniqueIdentifier)
-
-	if _, ok := v.(sql.Scanner); !ok {
-		t.Error(`Uniqueidentifier must be "database/sql".Scanner`)
-	}
-}
-
-func TestUniqueIdentifierImplementsValuer(t *testing.T) {
-	var v interface{}
-	v = new(UniqueIdentifier)
-
-	if _, ok := v.(driver.Valuer); !ok {
-		t.Error(`Uniqueidentifier must be "database/sql/driver".Valuer`)
-	}
-}
+var _ fmt.Stringer = UniqueIdentifier{}
+var _ sql.Scanner = &UniqueIdentifier{}
+var _ driver.Valuer = UniqueIdentifier{}

--- a/uniqueidentifier_test.go
+++ b/uniqueidentifier_test.go
@@ -1,0 +1,117 @@
+package mssql
+
+import (
+	"bytes"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"testing"
+)
+
+func TestUniqueIdentifier(t *testing.T) {
+	dbUUID := []byte{0x67, 0x45, 0x23, 0x01,
+		0xAB, 0x89,
+		0xEF, 0xCD,
+		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+	}
+
+	uuid := []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
+
+	t.Run("Scan", func(t *testing.T) {
+		t.Run("[]byte", func(t *testing.T) {
+			sut := new(UniqueIdentifier)
+			if err := sut.Scan(dbUUID); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal([]byte(*sut), uuid) {
+				t.Errorf("bytes not swapped correctly: got %q; want %q", []byte(*sut), uuid)
+			}
+		})
+
+		t.Run("string", func(t *testing.T) {
+			sut := new(UniqueIdentifier)
+			if err := sut.Scan(UniqueIdentifier(uuid).String()); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal([]byte(*sut), uuid) {
+				t.Errorf("string not scanned correctly: got %q; want %q", *sut, uuid)
+			}
+		})
+	})
+
+	t.Run("Value", func(t *testing.T) {
+		sut := UniqueIdentifier(uuid)
+		v, err := sut.Value()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b, ok := v.([]byte)
+		if !ok {
+			t.Fatalf("(%T) is not []byte", v)
+		}
+
+		if !bytes.Equal(b, dbUUID) {
+			t.Errorf("got %q; want %q", b, dbUUID)
+		}
+	})
+
+	t.Run("Equal", func(t *testing.T) {
+		sut := make(UniqueIdentifier, len(uuid))
+		uuid2 := make(UniqueIdentifier, len(uuid))
+
+		copy(sut, uuid)
+		copy(uuid2, uuid)
+
+		if actual := sut.Equal(uuid2); actual != true {
+			t.Errorf("sut.Equal(uuid2) = %t; want %t", actual, true)
+		}
+	})
+
+	t.Run("NotEqual", func(t *testing.T) {
+		sut := make(UniqueIdentifier, len(uuid))
+		uuid2 := make(UniqueIdentifier, len(uuid))
+
+		copy(sut, uuid)
+		copy(uuid2, dbUUID)
+
+		if actual := sut.Equal(uuid2); actual != false {
+			t.Errorf("sut.Equal(uuid2) = %t; want %t", actual, true)
+		}
+	})
+}
+
+func TestUniqueIdentifierString(t *testing.T) {
+	sut := UniqueIdentifier{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
+	expected := "01234567-89ab-cdef-0123-456789abcdef"
+	if actual := sut.String(); actual != expected {
+		t.Errorf("sut.String() = %s; want %s", sut, expected)
+	}
+}
+
+func TestUniqueIdentifierImplementsStringer(t *testing.T) {
+	var v interface{}
+	v = new(UniqueIdentifier)
+
+	if _, ok := v.(fmt.Stringer); !ok {
+		t.Error(`Uniqueidentifier must be fmt.Stringer`)
+	}
+
+}
+func TestUniqueIdentifierImplementsScanner(t *testing.T) {
+	var v interface{}
+	v = new(UniqueIdentifier)
+
+	if _, ok := v.(sql.Scanner); !ok {
+		t.Error(`Uniqueidentifier must be "database/sql".Scanner`)
+	}
+}
+
+func TestUniqueIdentifierImplementsValuer(t *testing.T) {
+	var v interface{}
+	v = new(UniqueIdentifier)
+
+	if _, ok := v.(driver.Valuer); !ok {
+		t.Error(`Uniqueidentifier must be "database/sql/driver".Valuer`)
+	}
+}

--- a/uniqueidentifier_test.go
+++ b/uniqueidentifier_test.go
@@ -9,38 +9,38 @@ import (
 )
 
 func TestUniqueIdentifier(t *testing.T) {
-	dbUUID := []byte{0x67, 0x45, 0x23, 0x01,
+	dbUUID := UniqueIdentifier{0x67, 0x45, 0x23, 0x01,
 		0xAB, 0x89,
 		0xEF, 0xCD,
 		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
 	}
 
-	uuid := []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
+	uuid := UniqueIdentifier{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
 
 	t.Run("Scan", func(t *testing.T) {
 		t.Run("[]byte", func(t *testing.T) {
-			sut := new(UniqueIdentifier)
-			if err := sut.Scan(dbUUID); err != nil {
+			var sut UniqueIdentifier
+			if err := sut.Scan(dbUUID[:]); err != nil {
 				t.Fatal(err)
 			}
-			if !bytes.Equal([]byte(*sut), uuid) {
-				t.Errorf("bytes not swapped correctly: got %q; want %q", []byte(*sut), uuid)
+			if sut != uuid {
+				t.Errorf("bytes not swapped correctly: got %q; want %q", sut, uuid)
 			}
 		})
 
 		t.Run("string", func(t *testing.T) {
-			sut := new(UniqueIdentifier)
-			if err := sut.Scan(UniqueIdentifier(uuid).String()); err != nil {
+			var sut UniqueIdentifier
+			if err := sut.Scan(uuid.String()); err != nil {
 				t.Fatal(err)
 			}
-			if !bytes.Equal([]byte(*sut), uuid) {
-				t.Errorf("string not scanned correctly: got %q; want %q", *sut, uuid)
+			if sut != uuid {
+				t.Errorf("string not scanned correctly: got %q; want %q", sut, uuid)
 			}
 		})
 	})
 
 	t.Run("Value", func(t *testing.T) {
-		sut := UniqueIdentifier(uuid)
+		sut := uuid
 		v, err := sut.Value()
 		if err != nil {
 			t.Fatal(err)
@@ -51,39 +51,15 @@ func TestUniqueIdentifier(t *testing.T) {
 			t.Fatalf("(%T) is not []byte", v)
 		}
 
-		if !bytes.Equal(b, dbUUID) {
+		if !bytes.Equal(b, dbUUID[:]) {
 			t.Errorf("got %q; want %q", b, dbUUID)
-		}
-	})
-
-	t.Run("Equal", func(t *testing.T) {
-		sut := make(UniqueIdentifier, len(uuid))
-		uuid2 := make(UniqueIdentifier, len(uuid))
-
-		copy(sut, uuid)
-		copy(uuid2, uuid)
-
-		if actual := sut.Equal(uuid2); actual != true {
-			t.Errorf("sut.Equal(uuid2) = %t; want %t", actual, true)
-		}
-	})
-
-	t.Run("NotEqual", func(t *testing.T) {
-		sut := make(UniqueIdentifier, len(uuid))
-		uuid2 := make(UniqueIdentifier, len(uuid))
-
-		copy(sut, uuid)
-		copy(uuid2, dbUUID)
-
-		if actual := sut.Equal(uuid2); actual != false {
-			t.Errorf("sut.Equal(uuid2) = %t; want %t", actual, true)
 		}
 	})
 }
 
 func TestUniqueIdentifierString(t *testing.T) {
 	sut := UniqueIdentifier{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
-	expected := "01234567-89ab-cdef-0123-456789abcdef"
+	expected := "01234567-89AB-CDEF-0123-456789ABCDEF"
 	if actual := sut.String(); actual != expected {
 		t.Errorf("sut.String() = %s; want %s", sut, expected)
 	}


### PR DESCRIPTION
SQL Server's UniqueIdentifier type uses native endianness for some of
its fields within the UUID. Add a new type, UniqueIdentifier, that
correctly handles scanning based on the type of data being scanned.

Scanning a []byte swaps the bytes of the fields that SQL Server stores
using native endianness.

Scanning a string decodes the hex-encoded values without swapping any
bytes.

Implement fmt.Stringer so that the returned value of String is congruent
with the behavior of CAST(myuniqueidentifer AS varchar(36)).