### PR TITLE
fix #200 When the underlying tcp connection is closed, go-mssql will attempt to read the mssql server loop.

### DIFF
--- a/token.go
+++ b/token.go
@@ -636,6 +636,9 @@ func processResponse(ctx context.Context, sess *tdsSession, ch chan tokenStruct)
 								}
 								return
 							}
+						case error:
+							ch <- tok
+							return
 						}
 					} else {
 						if err, ok := tok.(net.Error); ok && err.Timeout() {


### PR DESCRIPTION
When the underlying tcp connection is closed, go-mssql will attempt to read the mssql server loop.

The problem is solved by directly terminating the request after the error is found after the request is canceled.
But I am not sure that this has been ineffective Connection Go will be used again, I have not written go go sql driver, not clear how to delete the connection from the go sql connection pool.
The current test did not find the damaged connection will be re-used.****