### PR TITLE
mssql: add new driver type w/o pre-processing query

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,12 @@
+// package mssql implements the TDS protocol used to connect to MS SQL Server (sqlserver)
+// database servers.
+//
+// This package registers two drivers:
+//    sqlserver: uses native "@" parameter placeholder names and does no pre-processing.
+//    mssql: expects identifiers to be prefixed with ":" and pre-processes queries.
+//
+// If the ordinal position is used for query parameters, identifiers will be named
+// "@p1", "@p2", ... "@pN".
+//
+// Please refer to the REAME for the format of the DSN.
+package mssql

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -3,7 +3,7 @@ package mssql
 import "testing"
 
 func TestBadOpen(t *testing.T) {
-	drv := &MssqlDriver{}
+	drv := driverWithProcess(t)
 	_, err := drv.open("port=bad")
 	if err == nil {
 		t.Fail()

--- a/tds.go
+++ b/tds.go
@@ -84,13 +84,13 @@ const (
 // packet types
 // https://msdn.microsoft.com/en-us/library/dd304214.aspx
 const (
-	packSQLBatch packetType = 1
-	packRPCRequest  = 3
-	packReply       = 4
+	packSQLBatch   packetType = 1
+	packRPCRequest            = 3
+	packReply                 = 4
 
 	// 2.2.1.7 Attention: https://msdn.microsoft.com/en-us/library/dd341449.aspx
 	// 4.19.2 Out-of-Band Attention Signal: https://msdn.microsoft.com/en-us/library/dd305167.aspx
-	packAttention   = 6
+	packAttention = 6
 
 	packBulkLoadBCP = 7
 	packTransMgrReq = 14
@@ -643,7 +643,7 @@ func sendSqlBatch72(buf *tdsBuffer,
 
 // 2.2.1.7 Attention: https://msdn.microsoft.com/en-us/library/dd341449.aspx
 // 4.19.2 Out-of-Band Attention Signal: https://msdn.microsoft.com/en-us/library/dd305167.aspx
-func sendAttention(buf *tdsBuffer) (error) {
+func sendAttention(buf *tdsBuffer) error {
 	buf.BeginPacket(packAttention)
 	return buf.FinishPacket()
 }
@@ -1145,7 +1145,7 @@ func dialConnection(p connectParams) (conn net.Conn, err error) {
 	return conn, err
 }
 
-func connect(p connectParams) (res *tdsSession, err error) {
+func connect(log optionalLogger, p connectParams) (res *tdsSession, err error) {
 	res = nil
 	// if instance is specified use instance resolution service
 	if p.instance != "" {
@@ -1178,6 +1178,7 @@ initiate_connection:
 	outbuf := newTdsBuffer(4096, toconn)
 	sess := tdsSession{
 		buf:      outbuf,
+		log:      log,
 		logFlags: p.logFlags,
 	}
 

--- a/tran.go
+++ b/tran.go
@@ -1,6 +1,7 @@
+package mssql
+
 // Transaction Manager requests
 // http://msdn.microsoft.com/en-us/library/dd339887.aspx
-package mssql
 
 import (
 	"encoding/binary"
@@ -19,12 +20,12 @@ const (
 type isoLevel uint8
 
 const (
-	isolationUseCurrent isoLevel = 0
-	isolationReadUncommited = 1
-	isolationReadCommited = 2
-	isolationRepeatableRead = 3
-	isolationSerializable = 4
-	isolationSnapshot = 5
+	isolationUseCurrent     isoLevel = 0
+	isolationReadUncommited          = 1
+	isolationReadCommited            = 2
+	isolationRepeatableRead          = 3
+	isolationSerializable            = 4
+	isolationSnapshot                = 5
 )
 
 func sendBeginXact(buf *tdsBuffer, headers []headerStruct, isolation isoLevel,


### PR DESCRIPTION
There exists many queries today that uses native "@" placeholders
for queries. Parsing queries today is not perfect and introduces
more work that isn't always needed. Introduce a new driver type
that when used will not preprocess any queries.

Fixes #199