### PR TITLE
bulk copy for decimal types

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -516,7 +516,7 @@ func (b *MssqlBulk) makeParam(val DataValue, col columnStruct) (res Param, err e
 		}
 
 	// case typeMoney, typeMoney4, typeMoneyN:
-	case typeDecimal, typeDecimalN:
+	case typeDecimal, typeDecimalN, typeNumeric, typeNumericN:
 		var value float64
 		if v, ok := val.(float64); ok {
 			value = v
@@ -532,7 +532,6 @@ func (b *MssqlBulk) makeParam(val DataValue, col columnStruct) (res Param, err e
 			return res, err
 		}
 		dec.prec = perc
-		dec.scale = scale
 
 		var length byte
 		switch {

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -2,7 +2,6 @@ package mssql
 
 import (
 	"bytes"
-	_ "database/sql/driver"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -141,7 +140,7 @@ func (b *MssqlBulk) sendBulkCommand() (err error) {
 // AddRow immediately writes the row to the destination table.
 // The arguments are the row values in the order they were specified.
 func (b *MssqlBulk) AddRow(row []interface{}) (err error) {
-	if b.headerSent == false {
+	if !b.headerSent {
 		err = b.sendBulkCommand()
 		if err != nil {
 			return

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -557,18 +557,15 @@ func (b *MssqlBulk) makeParam(val DataValue, col columnStruct) (res Param, err e
 		}
 
 		ub := dec.UnscaledBytes()
-		if len(ub) > int(length) {
+		l := len(ub)
+		if l > int(length) {
 			err = fmt.Errorf("decimal out of range: %s", dec)
 			return res, err
 		}
-
 		// reverse the bytes
-		l := len(ub)
-		reverse := make([]byte, l)
-		for i, j := 0, l-1; i < l; i, j = i+1, j-1 {
-			reverse[i] = ub[j]
+		for i, j := 1, l-1; j >= 0; i, j = i+1, j-1 {
+			buf[i] = ub[j]
 		}
-		copy(buf[1:], reverse)
 		res.buffer = buf
 	case typeBigVarBin:
 		switch val := val.(type) {

--- a/bulkcopy_sql.go
+++ b/bulkcopy_sql.go
@@ -4,7 +4,6 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"strings"
 )
 
 type copyin struct {
@@ -90,8 +89,4 @@ func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 
 func (ci *copyin) Close() (err error) {
 	return nil
-}
-
-func isBulkInsert(query string) bool {
-	return len(query) > 10 && strings.EqualFold(query[:10], "INSERTBULK")
 }

--- a/bulkcopy_sql.go
+++ b/bulkcopy_sql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"strings"
 )
 
 type copyin struct {
@@ -89,4 +90,8 @@ func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 
 func (ci *copyin) Close() (err error) {
 	return nil
+}
+
+func isBulkInsert(query string) bool {
+	return len(query) > 10 && strings.EqualFold(query[:10], "INSERTBULK")
 }

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -48,11 +48,11 @@ func TestBulkcopy(t *testing.T) {
 		{"test_bigint", 9223372036854775807},
 		{"test_bigintn", nil},
 		{"test_geom", geom},
-		//{"test_smallmoney", nil},
-		//{"test_money", nil},
-		//{"test_decimal_18_0", nil},
-		//{"test_decimal_9_2", nil},
-		//{"test_decimal_18_0", nil},
+		// {"test_smallmoney", 1234.56},
+		// {"test_money", 1234.56},
+		{"test_decimal_18_0", 1234.0001},
+		{"test_decimal_9_2", 1234.560001},
+		{"test_decimal_20_0", 1234.0001},
 	}
 
 	columns := make([]string, len(testValues))
@@ -116,7 +116,7 @@ func TestBulkcopy(t *testing.T) {
 		}
 		for i, c := range testValues {
 			if !compareValue(container[i], c.val) {
-				t.Errorf("columns %s : %s != %s\n", c.colname, container[i], c.val)
+				t.Errorf("columns %s : %s != %v\n", c.colname, container[i], c.val)
 			}
 		}
 	}
@@ -134,6 +134,11 @@ func compareValue(a interface{}, expected interface{}) bool {
 	case int64:
 		return int64(expected) == a
 	case float64:
+		if got, ok := a.([]uint8); ok {
+			var nf sql.NullFloat64
+			nf.Scan(got)
+			a = nf.Float64
+		}
 		return math.Abs(expected-a.(float64)) < 0.0001
 	default:
 		return reflect.DeepEqual(expected, a)

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -53,6 +53,7 @@ func TestBulkcopy(t *testing.T) {
 		{"test_decimal_18_0", 1234.0001},
 		{"test_decimal_9_2", 1234.560001},
 		{"test_decimal_20_0", 1234.0001},
+		{"test_numeric_30_10", 1234567.1234567},
 	}
 
 	columns := make([]string, len(testValues))
@@ -183,6 +184,7 @@ func setupTable(conn *sql.DB, tableName string) {
 	[test_decimal_18_0] [decimal](18, 0) NULL,
 	[test_decimal_9_2] [decimal](9, 2) NULL,
 	[test_decimal_20_0] [decimal](20, 0) NULL,
+	[test_numeric_30_10] [decimal](30, 10) NULL,
  CONSTRAINT [PK_` + tableName + `_id] PRIMARY KEY CLUSTERED 
 (
 	[id] ASC

--- a/decimal.go
+++ b/decimal.go
@@ -33,6 +33,10 @@ func (d Decimal) ToFloat64() float64 {
 }
 
 func Float64ToDecimal(f float64) (Decimal, error) {
+	return Float64ToDecimalScale(f, 20)
+}
+
+func Float64ToDecimalScale(f float64, scale uint8) (Decimal, error) {
 	var dec Decimal
 	if math.IsNaN(f) {
 		return dec, errors.New("NaN")
@@ -49,7 +53,7 @@ func Float64ToDecimal(f float64) (Decimal, error) {
 	}
 	dec.prec = 20
 	var integer float64
-	for dec.scale = 0; dec.scale <= 20; dec.scale++ {
+	for dec.scale = 0; dec.scale <= scale; dec.scale++ {
 		integer = f * scaletblflt64[dec.scale]
 		_, frac := math.Modf(integer)
 		if frac == 0 {
@@ -73,7 +77,7 @@ func init() {
 	}
 }
 
-func (d Decimal) Bytes() []byte {
+func (d Decimal) BigInt() big.Int {
 	bytes := make([]byte, 16)
 	binary.BigEndian.PutUint32(bytes[0:4], d.integer[3])
 	binary.BigEndian.PutUint32(bytes[4:8], d.integer[2])
@@ -84,7 +88,17 @@ func (d Decimal) Bytes() []byte {
 	if !d.positive {
 		x.Neg(&x)
 	}
+	return x
+}
+
+func (d Decimal) Bytes() []byte {
+	x := d.BigInt()
 	return scaleBytes(x.String(), d.scale)
+}
+
+func (d Decimal) UnscaledBytes() []byte {
+	x := d.BigInt()
+	return x.Bytes()
 }
 
 func scaleBytes(s string, scale uint8) []byte {

--- a/decimal.go
+++ b/decimal.go
@@ -32,8 +32,10 @@ func (d Decimal) ToFloat64() float64 {
 	return val
 }
 
+const autoScale = 100
+
 func Float64ToDecimal(f float64) (Decimal, error) {
-	return Float64ToDecimalScale(f, 20)
+	return Float64ToDecimalScale(f, autoScale)
 }
 
 func Float64ToDecimalScale(f float64, scale uint8) (Decimal, error) {
@@ -56,7 +58,7 @@ func Float64ToDecimalScale(f float64, scale uint8) (Decimal, error) {
 	for dec.scale = 0; dec.scale <= scale; dec.scale++ {
 		integer = f * scaletblflt64[dec.scale]
 		_, frac := math.Modf(integer)
-		if frac == 0 {
+		if frac == 0 && scale == autoScale {
 			break
 		}
 	}

--- a/mssql_go18.go
+++ b/mssql_go18.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
-	"strings"
 )
 
 var _ driver.Pinger = &MssqlConn{}
@@ -52,9 +51,10 @@ func (c *MssqlConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.
 }
 
 func (c *MssqlConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
-	if len(query) > 10 && strings.EqualFold(query[:10], "INSERTBULK") {		
+	if isBulkInsert(query) {
 		return c.prepareCopyIn(query)
 	}
+
 	return c.prepareContext(ctx, query)
 }
 

--- a/mssql_go18.go
+++ b/mssql_go18.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"strings"
 )
 
 var _ driver.Pinger = &MssqlConn{}
@@ -51,7 +52,7 @@ func (c *MssqlConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.
 }
 
 func (c *MssqlConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
-	if isBulkInsert(query) {
+	if len(query) > 10 && strings.EqualFold(query[:10], "INSERTBULK") {
 		return c.prepareCopyIn(query)
 	}
 

--- a/types.go
+++ b/types.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 	"strconv"
 	"time"
-	"reflect"
 )
 
 // fixed-length data types
@@ -252,7 +252,7 @@ func decodeDateTime(buf []byte) time.Time {
 		0, 0, secs, ns, time.UTC)
 }
 
-func readFixedType(ti *typeInfo, r *tdsBuffer) (interface{}) {
+func readFixedType(ti *typeInfo, r *tdsBuffer) interface{} {
 	r.ReadFull(ti.Buffer)
 	buf := ti.Buffer
 	switch ti.TypeId {
@@ -286,7 +286,7 @@ func readFixedType(ti *typeInfo, r *tdsBuffer) (interface{}) {
 	panic("shoulnd't get here")
 }
 
-func readByteLenType(ti *typeInfo, r *tdsBuffer) (interface{}) {
+func readByteLenType(ti *typeInfo, r *tdsBuffer) interface{} {
 	size := r.byte()
 	if size == 0 {
 		return nil
@@ -381,7 +381,7 @@ func writeByteLenType(w io.Writer, ti typeInfo, buf []byte) (err error) {
 	return
 }
 
-func readShortLenType(ti *typeInfo, r *tdsBuffer) (interface{}) {
+func readShortLenType(ti *typeInfo, r *tdsBuffer) interface{} {
 	size := r.uint16()
 	if size == 0xffff {
 		return nil
@@ -424,7 +424,7 @@ func writeShortLenType(w io.Writer, ti typeInfo, buf []byte) (err error) {
 	return
 }
 
-func readLongLenType(ti *typeInfo, r *tdsBuffer) (interface{}) {
+func readLongLenType(ti *typeInfo, r *tdsBuffer) interface{} {
 	// information about this format can be found here:
 	// http://msdn.microsoft.com/en-us/library/dd304783.aspx
 	// and here:
@@ -485,7 +485,7 @@ func writeLongLenType(w io.Writer, ti typeInfo, buf []byte) (err error) {
 
 // reads variant value
 // http://msdn.microsoft.com/en-us/library/dd303302.aspx
-func readVariantType(ti *typeInfo, r *tdsBuffer) (interface{}) {
+func readVariantType(ti *typeInfo, r *tdsBuffer) interface{} {
 	size := r.int32()
 	if size == 0 {
 		return nil
@@ -577,7 +577,7 @@ func readVariantType(ti *typeInfo, r *tdsBuffer) (interface{}) {
 
 // partially length prefixed stream
 // http://msdn.microsoft.com/en-us/library/dd340469.aspx
-func readPLPType(ti *typeInfo, r *tdsBuffer) (interface{}) {
+func readPLPType(ti *typeInfo, r *tdsBuffer) interface{} {
 	size := r.uint64()
 	var buf *bytes.Buffer
 	switch size {
@@ -1001,6 +1001,8 @@ func makeDecl(ti typeInfo) string {
 		}
 	case typeDecimal, typeDecimalN:
 		return fmt.Sprintf("decimal(%d, %d)", ti.Prec, ti.Scale)
+	case typeNumeric, typeNumericN:
+		return fmt.Sprintf("numeric(%d, %d)", ti.Prec, ti.Scale)
 	case typeMoney4:
 		return "smallmoney"
 	case typeMoney:


### PR DESCRIPTION
decimal types first pass. money types should be the same, but not working for some reason. Submitting decimal types only this time

Reference: https://github.com/Microsoft/mssql-jdbc/blob/master/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java#L3307