### PR TITLE
Modified to cater for 0 byte length BVarChars. Fixing an unwanted io.EOF error.

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"golang.org/x/net/context" // use the "x/net/context" for backwards compatibility.
 	"io"
 	"io/ioutil"
 	"net"
@@ -18,7 +19,6 @@ import (
 	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
-	"golang.org/x/net/context" // use the "x/net/context" for backwards compatibility.
 )
 
 func parseInstances(msg []byte) map[string]map[string]string {
@@ -498,6 +498,11 @@ func readBVarChar(r io.Reader) (res string, err error) {
 	err = binary.Read(r, binary.LittleEndian, &numchars)
 	if err != nil {
 		return "", err
+	}
+
+	// A zero length could be returned, return an empty string
+	if numchars == 0 {
+		return "", nil
 	}
 	return readUcs2(r, int(numchars))
 }
@@ -1298,7 +1303,7 @@ continue_login:
 		case error:
 			return nil, fmt.Errorf("Login error: %s", token.Error())
 		case doneStruct:
-			if token.isError(){
+			if token.isError() {
 				return nil, fmt.Errorf("Login error: %s", token.getError())
 			}
 		}

--- a/token.go
+++ b/token.go
@@ -149,27 +149,23 @@ func processEnvChg(sess *tdsSession) {
 				badStreamPanic(err)
 			}
 		case envTypLanguage:
-			//currently ignored
-			// old value
-			_, err = readBVarChar(r)
-			if err != nil {
+			// currently ignored
+			// new value
+			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
-			// new value
-			_, err = readBVarChar(r)
-			if err != nil {
+			// old value
+			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
 		case envTypCharset:
-			//currently ignored
-			// old value
-			_, err = readBVarChar(r)
-			if err != nil {
+			// currently ignored
+			// new value
+			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
-			// new value
-			_, err = readBVarChar(r)
-			if err != nil {
+			// old value
+			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
 		case envTypPacketSize:
@@ -188,31 +184,52 @@ func processEnvChg(sess *tdsSession) {
 			sess.buf.ResizeBuffer(packetsizei)
 		case envSortId:
 			// currently ignored
-			// old value, should be 0
+			// new value
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
-			// new value
+			// old value, should be 0
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
 		case envSortFlags:
 			// currently ignored
-			// old value, should be 0
+			// new value
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
-			// new value
+			// old value, should be 0
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
 		case envSqlCollation:
 			// currently ignored
-			// old value
-			if _, err = readBVarChar(r); err != nil {
+			var collationSize uint8
+			err = binary.Read(r, binary.LittleEndian, &collationSize)
+			if err != nil {
 				badStreamPanic(err)
 			}
-			// new value
+
+			// SQL Collation data should contain 5 bytes in length
+			if collationSize != 5 {
+				badStreamPanicf("Invalid SQL Collation size value returned from server: %s", collationSize)
+			}
+
+			// 4 bytes, contains: LCID ColFlags Version
+			var info uint32
+			err = binary.Read(r, binary.LittleEndian, &info)
+			if err != nil {
+				badStreamPanic(err)
+			}
+
+			// 1 byte, contains: sortID
+			var sortID uint8
+			err = binary.Read(r, binary.LittleEndian, &sortID)
+			if err != nil {
+				badStreamPanic(err)
+			}
+
+			// old value, should be 0
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
@@ -251,21 +268,21 @@ func processEnvChg(sess *tdsSession) {
 			sess.tranid = 0
 		case envEnlistDTC:
 			// currently ignored
-			// old value
+			// new value, should be 0
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
-			// new value, should be 0
+			// old value
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
 		case envDefectTran:
 			// currently ignored
-			// old value, should be 0
+			// new value
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}
-			// new value
+			// old value, should be 0
 			if _, err = readBVarChar(r); err != nil {
 				badStreamPanic(err)
 			}


### PR DESCRIPTION
ENVCHANGE data can send a 0 byte length BVarChar. SqlCollation is a perfect example of this:

     227 8 0 7 5 9 4 16 32 0 0

The above when being parsed will cause an io.EOF error and is sent every time you connect to Azure SQL Data Warehouse (SQLDW).

Modified readBVarChar to cater for this, plus additional modifications to the SqlCollation parsing to be in accordance with the specification and ready for future changes.