### PR TITLE
LastInsertId - user SCOPE_IDENTITY, not @@IDENTITY

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -590,7 +590,7 @@ func (r *MssqlResult) RowsAffected() (int64, error) {
 }
 
 func (r *MssqlResult) LastInsertId() (int64, error) {
-	s, err := r.c.Prepare("select cast(@@identity as bigint)")
+	s, err := r.c.Prepare("select cast(SCOPE_IDENTITY() as bigint)")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
@@IDENTITY can return unexpected results if an insert has side-effects which create identity values in other tables, such as firing an AFTER INSERT triggers.

Using SCOPE_IDENTITY() instead resolves this problem.

[MS documentation](https://docs.microsoft.com/en-us/sql/t-sql/functions/scope-identity-transact-sql)

(This was previously discussed under #133 - the user who raised it closed the issue because SCOPE_IDENTITY went out of scope before it was called. However, @@IDENTITY and SCOPE_IDENTITY both go out of scope when a session ends, so from that perspective, this change has no functional impact.)