### PR TITLE
Support connecting over named pipes

### DIFF
--- a/namedpipe_unix.go
+++ b/namedpipe_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package mssql
+
+import (
+	"fmt"
+	"net"
+)
+
+func dialConnectionUsingNamedPipe(p connectParams) (conn net.Conn, err error) {
+	return nil, fmt.Errorf(
+		"Named pipe protocol (\"%s\") is implemented only for Windows OS",
+		p.protocol)
+}

--- a/namedpipe_windows.go
+++ b/namedpipe_windows.go
@@ -1,0 +1,20 @@
+// +build windows
+
+package mssql
+
+import (
+	"fmt"
+	"gopkg.in/natefinch/npipe.v2"
+	"net"
+)
+
+func dialConnectionUsingNamedPipe(p connectParams) (conn net.Conn, err error) {
+	conn, err = npipe.Dial(p.host)
+
+	if err != nil {
+		f := "Unable to open named pipe connection with address '%v': %v"
+		return nil, fmt.Errorf(f, p.host, err.Error())
+	}
+
+	return conn, err
+}

--- a/protocol.go
+++ b/protocol.go
@@ -1,0 +1,9 @@
+package mssql
+
+type Protocol string
+
+const (
+	TCP           Protocol = "tcp:"
+	NAMED_PIPE    Protocol = "np:"
+	SHARED_MEMORY Protocol = "lpc:"
+)

--- a/tds.go
+++ b/tds.go
@@ -656,9 +656,9 @@ func sendAttention(buf *tdsBuffer) error {
 type connectParams struct {
 	logFlags               uint64
 	protocol               Protocol
-	port                   uint64
 	host                   string
-	instance               string
+	port                   uint64 // Used only if protocol == TCP
+	instance               string // Not used if protocol == NAMED_PIPE
 	database               string
 	user                   string
 	password               string
@@ -957,13 +957,17 @@ func parseConnectParams(dsn string) (connectParams, error) {
 		}
 	}
 
-	parts := strings.SplitN(server, "\\", 2)
-	p.host = parts[0]
-	if p.host == "." || strings.ToUpper(p.host) == "(LOCAL)" || p.host == "" {
-		p.host = "localhost"
-	}
-	if len(parts) > 1 {
-		p.instance = parts[1]
+	if p.protocol == NAMED_PIPE {
+		p.host = server
+	} else {
+		parts := strings.SplitN(server, "\\", 2)
+		p.host = parts[0]
+		if p.host == "." || strings.ToUpper(p.host) == "(LOCAL)" || p.host == "" {
+			p.host = "localhost"
+		}
+		if len(parts) > 1 {
+			p.instance = parts[1]
+		}
 	}
 	p.database = params["database"]
 	p.user = params["user id"]

--- a/tds.go
+++ b/tds.go
@@ -1132,7 +1132,7 @@ func dialConnection(p connectParams) (conn net.Conn, err error) {
 	case TCP:
 		return dialConnectionUsingTCP(p)
 	case NAMED_PIPE:
-		return nil, fmt.Errorf("Named pipe protocol (\"%s\") is not implemented yet", p.protocol)
+		return dialConnectionUsingNamedPipe(p)
 	case SHARED_MEMORY:
 		return nil, fmt.Errorf("Shared memory protocol (\"%s\") is not implemented yet", p.protocol)
 	default:

--- a/tds.go
+++ b/tds.go
@@ -1127,10 +1127,23 @@ type Auth interface {
 	Free()
 }
 
+func dialConnection(p connectParams) (conn net.Conn, err error) {
+	switch p.protocol {
+	case TCP:
+		return dialConnectionUsingTCP(p)
+	case NAMED_PIPE:
+		return nil, fmt.Errorf("Named pipe protocol (\"%s\") is not implemented yet", p.protocol)
+	case SHARED_MEMORY:
+		return nil, fmt.Errorf("Shared memory protocol (\"%s\") is not implemented yet", p.protocol)
+	default:
+		return nil, fmt.Errorf("Invalid value '%+v' for Protocol type", p.protocol)
+	}
+}
+
 // SQL Server AlwaysOn Availability Group Listeners are bound by DNS to a
 // list of IP addresses.  So if there is more than one, try them all and
 // use the first one that allows a connection.
-func dialConnection(p connectParams) (conn net.Conn, err error) {
+func dialConnectionUsingTCP(p connectParams) (conn net.Conn, err error) {
 	var ips []net.IP
 	ips, err = net.LookupIP(p.host)
 	if err != nil {


### PR DESCRIPTION
With PR, go-mssqldb will support connecting over named pipes with **no** breaking changes.

### Motivation
Connecting to the DB over named-pipe instead of TCP gives you both performance improvement and guarantee the safety. By prohibiting the TCP connection to the DB, you'll be ensured that your DB is opened only for the local processes. And also in rare circumstances, some sysadmins are *forced* to block TCP connection due to a legacy reason.

Sadly, current implementation of go-mssql support only TCP connection. But still, thanks to the good abstraction of current go-mssqldb structure, I could easily extend the code to support not only the TCP connection but also the named pipe connection or something else.

I hereby open a PR which closes the #96. Please feel free to propose a change or a better design.

### Design
Current go-mssqldb will always try to connect to the DB using TCP.

```
# It'll be always TCP
server=localhost;user id=USER;password=PASSWORD;database=master
```

With this PR being merged, users will be able to explicitly choose a protocol.

```
# TCP (Omitting the protocol will defaults to TCP to preserve backward compatibility)
server=localhost;user id=USER;password=PASSWORD;database=master

# TCP
server=tcp:localhost;user id=USER;password=PASSWORD;database=master

# Named pipe (It works only in Windows)
server=np:\\.\pipe\sql\query;user id=USER;password=PASSWORD;database=master

# Shared Memory (It'll always return "not implemented yet" error)
server=lpc:.\SQLEXPRESS;user id=USER;password=PASSWORD;database=master
```

This format is intended to be resembled with the actual ADO's connection string format. This will let us be able to solve issue #96 without introducing any breaking changes.

If you build go-mssqldb targetting the non-Windows environment, using named pipe or shared memory protocol will causes "not implemented yet" error.

### References
- https://github.com/denisenkom/go-mssqldb/issues/96
- [Creating a Valid Connection String Using Named Pipes](https://technet.microsoft.com/en-us/library/ms189307(v=sql.105).aspx) by MSDN
- [SqlConnection.ConnectionString Property](https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.connectionstring(v=vs.110).aspx#code-snippet-4) by MSDN

<br>

Closes #96