### PR TITLE
Allow use local time instead on UTC

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -484,7 +484,7 @@ func (b *MssqlBulk) makeParam(val DataValue, col columnStruct) (res Param, err e
 				res.ti.Size = 4
 				res.buffer = make([]byte, 4)
 
-				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, Location)
 				dur := val.Sub(ref)
 				days := dur / (24 * time.Hour)
 				if days < 0 {
@@ -499,7 +499,7 @@ func (b *MssqlBulk) makeParam(val DataValue, col columnStruct) (res Param, err e
 				res.ti.Size = 8
 				res.buffer = make([]byte, 8)
 
-				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, Location)
 				dur := val.Sub(ref)
 				days := math.Floor(float64(dur) / float64(24*time.Hour))
 				tm := (val.Hour()*60*60+val.Minute()*60+val.Second())*300 + int(val.Nanosecond()/10000000*3)

--- a/mssql.go
+++ b/mssql.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+var Location = time.UTC
+
 var driverInstance = &MssqlDriver{processQueryText: true}
 var driverInstanceNoProcess = &MssqlDriver{processQueryText: false}
 
@@ -626,7 +628,7 @@ func (s *MssqlStmt) makeParam(val driver.Value) (res Param, err error) {
 			res.ti.TypeId = typeDateTimeN
 			res.ti.Size = 8
 			res.buffer = make([]byte, 8)
-			ref := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+			ref := time.Date(1900, 1, 1, 0, 0, 0, 0, Location)
 			dur := val.Sub(ref)
 			days := dur / (24 * time.Hour)
 			tm := (300 * (dur % (24 * time.Hour))) / time.Second

--- a/types.go
+++ b/types.go
@@ -240,7 +240,7 @@ func decodeDateTim4(buf []byte) time.Time {
 	days := binary.LittleEndian.Uint16(buf)
 	mins := binary.LittleEndian.Uint16(buf[2:])
 	return time.Date(1900, 1, 1+int(days),
-		0, int(mins), 0, 0, time.UTC)
+		0, int(mins), 0, 0, Location)
 }
 
 func decodeDateTime(buf []byte) time.Time {
@@ -782,7 +782,7 @@ func decodeDateInt(buf []byte) (days int) {
 }
 
 func decodeDate(buf []byte) time.Time {
-	return time.Date(1, 1, 1+decodeDateInt(buf), 0, 0, 0, 0, time.UTC)
+	return time.Date(1, 1, 1+decodeDateInt(buf), 0, 0, 0, 0, Location)
 }
 
 func decodeTimeInt(scale uint8, buf []byte) (sec int, ns int) {
@@ -802,14 +802,14 @@ func decodeTimeInt(scale uint8, buf []byte) (sec int, ns int) {
 
 func decodeTime(scale uint8, buf []byte) time.Time {
 	sec, ns := decodeTimeInt(scale, buf)
-	return time.Date(1, 1, 1, 0, 0, sec, ns, time.UTC)
+	return time.Date(1, 1, 1, 0, 0, sec, ns, Location)
 }
 
 func decodeDateTime2(scale uint8, buf []byte) time.Time {
 	timesize := len(buf) - 3
 	sec, ns := decodeTimeInt(scale, buf[:timesize])
 	days := decodeDateInt(buf[timesize:])
-	return time.Date(1, 1, 1+days, 0, 0, sec, ns, time.UTC)
+	return time.Date(1, 1, 1+days, 0, 0, sec, ns, Location)
 }
 
 func decodeDateTimeOffset(scale uint8, buf []byte) time.Time {


### PR DESCRIPTION
Closes #225

This patch allow tell the driver to return time types in other locations than UTC:

```go
mssql.Location = time.Local
```