### PR TITLE
mssql: support OUTPUT parameters, detect PROC names

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
-
-	"strconv"
 
 	"golang.org/x/net/context" // use the "x/net/context" for backwards compatibility.
 )
@@ -218,7 +217,7 @@ func (b *MssqlBulk) Done() (rowcount int64, err error) {
 	buf.FinishPacket()
 
 	tokchan := make(chan tokenStruct, 5)
-	go processResponse(context.Background(), b.cn.sess, tokchan)
+	go processResponse(context.Background(), b.cn.sess, tokchan, nil)
 
 	var rowCount int64
 	for token := range tokchan {
@@ -309,7 +308,8 @@ func (s *MssqlStmt) QueryMeta() (cols []columnStruct, err error) {
 		return
 	}
 	tokchan := make(chan tokenStruct, 5)
-	go processResponse(context.Background(), s.c.sess, tokchan)
+	go processResponse(context.Background(), s.c.sess, tokchan, s.c.outs)
+	s.c.clearOuts()
 loop:
 	for tok := range tokchan {
 		switch token := tok.(type) {

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -1,4 +1,4 @@
-﻿package mssql
+package mssql
 
 import (
 	"database/sql"
@@ -74,7 +74,7 @@ func TestBulkcopy(t *testing.T) {
 	defer conn.Close()
 
 	err := setupTable(conn, tableName)
-	if (err != nil) {
+	if err != nil {
 		t.Error("Setup table failed: ", err.Error())
 		return
 	}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1,8 +1,8 @@
 package mssql
 
 import (
-	"testing"
 	"math"
+	"testing"
 )
 
 func TestToString(t *testing.T) {

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -1,0 +1,53 @@
+// +build go1.9
+
+package mssql
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	// "github.com/cockroachdb/apd"
+)
+
+var _ driver.NamedValueChecker = &MssqlConn{}
+
+func (c *MssqlConn) CheckNamedValue(nv *driver.NamedValue) error {
+	switch v := nv.Value.(type) {
+	case sql.Out:
+		if c.outs == nil {
+			c.outs = make(map[string]interface{})
+		}
+		c.outs[nv.Name] = v.Dest
+
+		// Unwrap the Out value and check the inner value.
+		lnv := *nv
+		lnv.Value = v.Dest
+		err := c.CheckNamedValue(&lnv)
+		if err != nil {
+			if err != driver.ErrSkip {
+				return err
+			}
+			lnv.Value, err = driver.DefaultParameterConverter.ConvertValue(lnv.Value)
+			if err != nil {
+				return err
+			}
+		}
+		nv.Value = sql.Out{Dest: lnv.Value}
+		return nil
+	// case *apd.Decimal:
+	// 	return nil
+	default:
+		return driver.ErrSkip
+	}
+}
+
+func (s *MssqlStmt) makeParamExtra(val driver.Value) (res Param, err error) {
+	switch val := val.(type) {
+	case sql.Out:
+		res, err = s.makeParam(val.Dest)
+		res.Flags = fByRevValue
+	default:
+		err = fmt.Errorf("mssql: unknown type for %T", val)
+	}
+	return
+}

--- a/mssql_go19pre.go
+++ b/mssql_go19pre.go
@@ -1,0 +1,12 @@
+// +build !go1.9
+
+package mssql
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+func (s *MssqlStmt) makeParamExtra(val driver.Value) (Param, error) {
+	return Param{}, fmt.Errorf("mssql: unknown type for %T", val)
+}

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -9,3 +9,22 @@ func TestBadOpen(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestIsProc(t *testing.T) {
+	list := []struct {
+		s  string
+		is bool
+	}{
+		{"proc", true},
+		{"select 1;", false},
+		{"[proc 1]", true},
+		{"[proc\n1]", false},
+	}
+
+	for _, item := range list {
+		got := isProc(item.s)
+		if got != item.is {
+			t.Errorf("for %q, got %t want %t", item.s, got, item.is)
+		}
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -13,7 +13,7 @@ type parser struct {
 	paramMax   int
 
 	// using map as a set
-	namedParams map [string]bool
+	namedParams map[string]bool
 }
 
 func (p *parser) next() (rune, bool) {
@@ -42,8 +42,8 @@ type stateFunc func(*parser) stateFunc
 
 func parseParams(query string) (string, int) {
 	p := &parser{
-		r: bytes.NewReader([]byte(query)),
-		namedParams: map [string]bool{},
+		r:           bytes.NewReader([]byte(query)),
+		namedParams: map[string]bool{},
 	}
 	state := parseNormal
 	for state != nil {

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -1,0 +1,99 @@
+// +build go1.9
+
+package mssql
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+func TestOutputParam(t *testing.T) {
+	sqltextcreate := `
+CREATE PROCEDURE abassign
+   @aid INT,
+   @bid INT OUTPUT
+AS
+BEGIN
+   SELECT @bid = @aid
+END;
+`
+	sqltextdrop := `DROP PROCEDURE abassign;`
+	sqltextrun := `abassign`
+
+	checkConnStr(t)
+	SetLogger(testLogger{t})
+
+	db, err := sql.Open("sqlserver", makeConnStr(t).String())
+	if err != nil {
+		t.Fatalf("failed to open driver sqlserver")
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db.ExecContext(ctx, sqltextdrop)
+	_, err = db.ExecContext(ctx, sqltextcreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bout int64
+	_, err = db.ExecContext(ctx, sqltextrun,
+		sql.Named("aid", 5),
+		sql.Named("bid", sql.Out{Dest: &bout}),
+	)
+	defer db.ExecContext(ctx, sqltextdrop)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if bout != 5 {
+		t.Errorf("expected 5, got %d", bout)
+	}
+}
+
+func TestOutputINOUTParam(t *testing.T) {
+	sqltextcreate := `
+CREATE PROCEDURE abinout
+   @aid INT,
+   @bid INT OUTPUT
+AS
+BEGIN
+   SELECT @bid = @aid + @bid;
+END;
+`
+	sqltextdrop := `DROP PROCEDURE abinout;`
+	sqltextrun := `abinout`
+
+	checkConnStr(t)
+	SetLogger(testLogger{t})
+
+	db, err := sql.Open("sqlserver", makeConnStr(t).String())
+	if err != nil {
+		t.Fatalf("failed to open driver sqlserver")
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db.ExecContext(ctx, sqltextdrop)
+	_, err = db.ExecContext(ctx, sqltextcreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bout int64 = 3
+	_, err = db.ExecContext(ctx, sqltextrun,
+		sql.Named("aid", 5),
+		sql.Named("bid", sql.Out{Dest: &bout}),
+	)
+	defer db.ExecContext(ctx, sqltextdrop)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if bout != 8 {
+		t.Errorf("expected 8, got %d", bout)
+	}
+}

--- a/queries_test.go
+++ b/queries_test.go
@@ -315,11 +315,11 @@ func TestNull(t *testing.T) {
 		"sql_variant",
 	}
 	for _, typ := range types {
-		row := conn.QueryRow("declare @x " + typ + " = ?; select @x", nil)
+		row := conn.QueryRow("declare @x "+typ+" = ?; select @x", nil)
 		var retval interface{}
 		err := row.Scan(&retval)
 		if err != nil {
-			t.Error("Scan failed for type " + typ, err.Error())
+			t.Error("Scan failed for type "+typ, err.Error())
 			return
 		}
 		if retval != nil {

--- a/tds.go
+++ b/tds.go
@@ -1313,7 +1313,7 @@ initiate_connection:
 	var sspi_msg []byte
 continue_login:
 	tokchan := make(chan tokenStruct, 5)
-	go processResponse(context.Background(), &sess, tokchan)
+	go processResponse(context.Background(), &sess, tokchan, nil)
 	success := false
 	for tok := range tokchan {
 		switch token := tok.(type) {

--- a/tds_go18_test.go
+++ b/tds_go18_test.go
@@ -1,11 +1,11 @@
 package mssql
 
 import (
-	"testing"
+	"database/sql"
+	"fmt"
 	"net/url"
 	"os"
-	"fmt"
-	"database/sql"
+	"testing"
 )
 
 func TestBadConnect(t *testing.T) {

--- a/tds_test.go
+++ b/tds_test.go
@@ -97,7 +97,7 @@ func TestSendSqlBatch(t *testing.T) {
 	}
 
 	ch := make(chan tokenStruct, 5)
-	go processResponse(context.Background(), conn, ch)
+	go processResponse(context.Background(), conn, ch, nil)
 
 	var lastRow []interface{}
 loop:

--- a/token.go
+++ b/token.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strconv"
@@ -24,6 +25,7 @@ const (
 	tokenOrder        token = 169 // 0xA9
 	tokenError        token = 170 // 0xAA
 	tokenInfo         token = 171 // 0xAB
+	tokenReturnValue  token = 0xAC
 	tokenLoginAck     token = 173 // 0xad
 	tokenRow          token = 209 // 0xd1
 	tokenNbcRow       token = 210 // 0xd2
@@ -519,7 +521,29 @@ func parseInfo(r *tdsBuffer) (res Error) {
 	return
 }
 
-func processSingleResponse(sess *tdsSession, ch chan tokenStruct) {
+// https://msdn.microsoft.com/en-us/library/dd303881.aspx
+func parseReturnValue(r *tdsBuffer) (nv namedValue) {
+	/*
+		ParamOrdinal
+		ParamName
+		Status
+		UserType
+		Flags
+		TypeInfo
+		CryptoMetadata
+		Value
+	*/
+	r.uint16()
+	nv.Name = r.BVarChar()
+	r.byte()
+	r.uint32() // UserType (uint16 prior to 7.2)
+	r.uint16()
+	ti := readTypeInfo(r)
+	nv.Value = ti.Reader(&ti, r)
+	return
+}
+
+func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[string]interface{}) {
 	defer func() {
 		if err := recover(); err != nil {
 			if sess.logFlags&logErrors != 0 {
@@ -614,10 +638,36 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct) {
 			if sess.logFlags&logMessages != 0 {
 				sess.log.Println(info.Message)
 			}
+		case tokenReturnValue:
+			nv := parseReturnValue(sess.buf)
+			if len(nv.Name) > 0 {
+				name := nv.Name[1:] // Remove the leading "@".
+				if ov, has := outs[name]; has {
+					err = scanIntoOut(nv.Value, ov)
+					if err != nil {
+						fmt.Println("scan error", err)
+						ch <- err
+					}
+				}
+			}
 		default:
 			badStreamPanic(driver.ErrBadConn)
 		}
 	}
+}
+
+func scanIntoOut(fromServer, scanInto interface{}) error {
+	switch fs := fromServer.(type) {
+	case int64:
+		switch si := scanInto.(type) {
+		case *int64:
+			*si = fs
+		default:
+			return fmt.Errorf("unsupported scan into type %[1]T for server type %[2]T", scanInto, fromServer)
+		}
+		return nil
+	}
+	return fmt.Errorf("unsupported type from server %[1]T=%[1]v", fromServer)
 }
 
 type parseRespIter byte
@@ -735,7 +785,7 @@ func (ts *parseResp) iter(ctx context.Context, ch chan tokenStruct, tokChan chan
 	}
 }
 
-func processResponse(ctx context.Context, sess *tdsSession, ch chan tokenStruct) {
+func processResponse(ctx context.Context, sess *tdsSession, ch chan tokenStruct, outs map[string]interface{}) {
 	ts := &parseResp{
 		sess:    sess,
 		ctxDone: ctx.Done(),
@@ -755,7 +805,7 @@ func processResponse(ctx context.Context, sess *tdsSession, ch chan tokenStruct)
 		ts.dlog("initiating response reading")
 
 		tokChan := make(chan tokenStruct)
-		go processSingleResponse(sess, tokChan)
+		go processSingleResponse(sess, tokChan, outs)
 
 		// Loop over multiple tokens in response.
 	tokensLoop:

--- a/types_test.go
+++ b/types_test.go
@@ -1,8 +1,8 @@
 package mssql
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 	"time"
 )
 


### PR DESCRIPTION
In go1.9 expect NamedValueChecker to land. Support OUTPUT
parameters and model how other types can be supported.