### PR TITLE
mssql: do not directly return driver.ErrBadConn, return actual error

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -69,15 +69,15 @@ func (w *tdsBuffer) PackageSize() uint32 {
 }
 
 func (w *tdsBuffer) flush() (err error) {
-	// writing packet size
+	// Write packet size.
 	binary.BigEndian.PutUint16(w.wbuf[2:], w.wpos)
 
-	// writing packet into underlying transport
+	// Write packet into underlying transport.
 	if _, err = w.transport.Write(w.wbuf[:w.wpos]); err != nil {
 		return err
 	}
 
-	// execute afterFirst hook if it is set
+	// Execute afterFirst hook if it is set.
 	if w.afterFirst != nil {
 		w.afterFirst()
 		w.afterFirst = nil

--- a/queries_test.go
+++ b/queries_test.go
@@ -898,8 +898,8 @@ func TestBeginTranError(t *testing.T) {
 
 	ctx := context.Background()
 	_, err = conn.begin(ctx, isolationSnapshot)
-	if err != driver.ErrBadConn {
-		t.Errorf("begin should fail with ErrBadConn but it returned %v", err)
+	if err == nil || conn.connectionGood == true {
+		t.Errorf("begin should fail as a bad connection, err=%v", err)
 	}
 
 	// reopen connection
@@ -941,8 +941,8 @@ func TestCommitTranError(t *testing.T) {
 
 	ctx := context.Background()
 	err = conn.Commit()
-	if err != driver.ErrBadConn {
-		t.Errorf("begin should fail with ErrBadConn but it returned %v", err)
+	if err == nil || conn.connectionGood {
+		t.Errorf("begin should fail and set the connection to bad, but it returned %v", err)
 	}
 
 	// reopen connection
@@ -999,8 +999,8 @@ func TestRollbackTranError(t *testing.T) {
 
 	ctx := context.Background()
 	err = conn.Rollback()
-	if err != driver.ErrBadConn {
-		t.Errorf("Rollback should fail with ErrBadConn but it returned %v", err)
+	if err == nil || conn.connectionGood {
+		t.Errorf("Rollback should fail and set connection to bad but it returned %v", err)
 	}
 
 	// reopen connection
@@ -1068,7 +1068,7 @@ func TestSendQueryErrors(t *testing.T) {
 
 	// should fail because connection is closed
 	_, err = stmt.Query([]driver.Value{})
-	if err != driver.ErrBadConn {
+	if err == nil || stmt.c.connectionGood {
 		t.Fail()
 	}
 
@@ -1078,7 +1078,7 @@ func TestSendQueryErrors(t *testing.T) {
 	}
 	// should fail because connection is closed
 	_, err = stmt.Query([]driver.Value{int64(1)})
-	if err != driver.ErrBadConn {
+	if err == nil || stmt.c.connectionGood {
 		t.Fail()
 	}
 }
@@ -1139,7 +1139,7 @@ func TestSendExecErrors(t *testing.T) {
 
 	// should fail because connection is closed
 	_, err = stmt.Exec([]driver.Value{})
-	if err != driver.ErrBadConn {
+	if err == nil || stmt.c.connectionGood {
 		t.Fail()
 	}
 
@@ -1149,7 +1149,7 @@ func TestSendExecErrors(t *testing.T) {
 	}
 	// should fail because connection is closed
 	_, err = stmt.Exec([]driver.Value{int64(1)})
-	if err != driver.ErrBadConn {
+	if err == nil || stmt.c.connectionGood {
 		t.Fail()
 	}
 }

--- a/tds.go
+++ b/tds.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"golang.org/x/net/context" // use the "x/net/context" for backwards compatibility.
 	"io"
 	"io/ioutil"
 	"net"
@@ -19,6 +18,8 @@ import (
 	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
+
+	"golang.org/x/net/context" // use the "x/net/context" for backwards compatibility.
 )
 
 func parseInstances(msg []byte) map[string]map[string]string {
@@ -1016,8 +1017,7 @@ func parseConnectParams(dsn string) (connectParams, error) {
 	// https://msdn.microsoft.com/en-us/library/dd341108.aspx
 	p.keepAlive = 30 * time.Second
 
-	keepAlive, ok := params["keepalive"]
-	if ok {
+	if keepAlive, ok := params["keepalive"]; ok {
 		timeout, err := strconv.ParseUint(keepAlive, 0, 16)
 		if err != nil {
 			f := "Invalid keepAlive value '%s': %s"
@@ -1254,8 +1254,7 @@ initiate_connection:
 		if p.certificate != "" {
 			pem, err := ioutil.ReadFile(p.certificate)
 			if err != nil {
-				f := "Cannot read certificate '%s': %s"
-				return nil, fmt.Errorf(f, p.certificate, err.Error())
+				return nil, fmt.Errorf("Cannot read certificate %q: %v", p.certificate, err)
 			}
 			certs := x509.NewCertPool()
 			certs.AppendCertsFromPEM(pem)
@@ -1269,11 +1268,11 @@ initiate_connection:
 		toconn.buf = outbuf
 		tlsConn := tls.Client(toconn, &config)
 		err = tlsConn.Handshake()
+
 		toconn.buf = nil
 		outbuf.transport = tlsConn
 		if err != nil {
-			f := "TLS Handshake failed: %s"
-			return nil, fmt.Errorf(f, err.Error())
+			return nil, fmt.Errorf("TLS Handshake failed: %v", err)
 		}
 		if encrypt == encryptOff {
 			outbuf.afterFirst = func() {

--- a/token.go
+++ b/token.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"database/sql/driver"
-
 	"golang.org/x/net/context"
 )
 
@@ -563,7 +561,7 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[strin
 		return
 	}
 	if packet_type != packReply {
-		badStreamPanic(driver.ErrBadConn)
+		badStreamPanic(fmt.Errorf("unexpected packet type in reply: got %v, expected %v", packet_type, packReply))
 	}
 	var columns []columnStruct
 	errs := make([]Error, 0, 5)
@@ -651,7 +649,7 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[strin
 				}
 			}
 		default:
-			badStreamPanic(driver.ErrBadConn)
+			badStreamPanic(fmt.Errorf("unknown token type returned: %v", token))
 		}
 	}
 }


### PR DESCRIPTION
Also set the connectionGood = false so next time it hits the driver,
it can remove the connection from the pool.

This prevents certain queries with errors being executed more then once.
