### PR TITLE
Fix #301 - ColumnTypes() panicking with timestamp and datetime columns

### DIFF
--- a/types.go
+++ b/types.go
@@ -964,6 +964,8 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 		return reflect.TypeOf("")
 	case typeImage:
 		return reflect.TypeOf([]byte{})
+	case typeBigBinary:
+		return reflect.TypeOf([]byte{})
 	case typeVariant:
 		return reflect.TypeOf(nil)
 	default:
@@ -1143,7 +1145,7 @@ func makeGoLangTypeName(ti typeInfo) string {
 		default:
 			panic("invalid size of MONEYN")
 		}
-	case typeDateTimeN:
+	case typeDateTimeN, typeDateTime:
 		switch ti.Size {
 		case 4:
 			return "SMALLDATETIME"
@@ -1178,6 +1180,8 @@ func makeGoLangTypeName(ti typeInfo) string {
 		return "IMAGE"
 	case typeVariant:
 		return "SQL_VARIANT"
+	case typeBigBinary:
+		return "TIMESTAMP"
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %d", ti.TypeId))
 	}
@@ -1244,7 +1248,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		default:
 			panic("invalid size of MONEYN")
 		}
-	case typeDateTimeN:
+	case typeDateTimeN, typeDateTime:
 		switch ti.Size {
 		case 4:
 			return 0, false
@@ -1296,6 +1300,8 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 	case typeImage:
 		return 2147483647, true
 	case typeVariant:
+		return 0, false
+	case typeBigBinary:
 		return 0, false
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %d", ti.TypeId))
@@ -1363,7 +1369,7 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		default:
 			panic("invalid size of MONEYN")
 		}
-	case typeDateTimeN:
+	case typeDateTimeN, typeDateTime:
 		switch ti.Size {
 		case 4:
 			return 0, 0, false
@@ -1403,6 +1409,8 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 	case typeImage:
 		return 0, 0, false
 	case typeVariant:
+		return 0, 0, false
+	case typeBigBinary:
 		return 0, 0, false
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %d", ti.TypeId))


### PR DESCRIPTION
Enables correct use of *columnTypes()* method on results that include columns of type *timestamp* (legacy type, implemented as typeBigBinary), and *datetime*.