### PR TITLE
Add support for typeDateTim4 and typeDateTime in switch statements

### DIFF
--- a/types.go
+++ b/types.go
@@ -345,6 +345,10 @@ func readByteLenType(ti *typeInfo, r *tdsBuffer) interface{} {
 		default:
 			badStreamPanicf("Invalid size for MONEYNTYPE")
 		}
+	case typeDateTim4:
+		return decodeDateTim4(buf)
+	case typeDateTime:
+		return decodeDateTime(buf)
 	case typeDateTimeN:
 		switch len(buf) {
 		case 4:
@@ -1052,10 +1056,10 @@ func makeDecl(ti typeInfo) string {
 		}
 	case typeBit, typeBitN:
 		return "bit"
-	case typeDateTim4:
-		return "smalldatetime"
 	case typeDateN:
 		return "date"
+	case typeDateTim4:
+		return "smalldatetime"
 	case typeDateTime:
 		return "datetime"
 	case typeDateTimeN:
@@ -1143,6 +1147,10 @@ func makeGoLangTypeName(ti typeInfo) string {
 		default:
 			panic("invalid size of MONEYN")
 		}
+	case typeDateTim4:
+		return "SMALLDATETIME"
+	case typeDateTime:
+		return "DATETIME"
 	case typeDateTimeN:
 		switch ti.Size {
 		case 4:
@@ -1244,6 +1252,8 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		default:
 			panic("invalid size of MONEYN")
 		}
+	case typeDateTim4, typeDateTime:
+		return 0, false
 	case typeDateTimeN:
 		switch ti.Size {
 		case 4:
@@ -1363,6 +1373,8 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		default:
 			panic("invalid size of MONEYN")
 		}
+	case typeDateTim4, typeDateTime:
+		return 0, 0, false
 	case typeDateTimeN:
 		switch ti.Size {
 		case 4:

--- a/types.go
+++ b/types.go
@@ -968,6 +968,8 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 		return reflect.TypeOf("")
 	case typeImage:
 		return reflect.TypeOf([]byte{})
+	case typeBigBinary:
+		return reflect.TypeOf([]byte{})
 	case typeVariant:
 		return reflect.TypeOf(nil)
 	default:
@@ -1186,6 +1188,8 @@ func makeGoLangTypeName(ti typeInfo) string {
 		return "IMAGE"
 	case typeVariant:
 		return "SQL_VARIANT"
+	case typeBigBinary:
+		return "BINARY"
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %d", ti.TypeId))
 	}
@@ -1307,6 +1311,8 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		return 2147483647, true
 	case typeVariant:
 		return 0, false
+	case typeBigBinary:
+		return 0, false
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %d", ti.TypeId))
 	}
@@ -1415,6 +1421,8 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 	case typeImage:
 		return 0, 0, false
 	case typeVariant:
+		return 0, 0, false
+	case typeBigBinary:
 		return 0, 0, false
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %d", ti.TypeId))

--- a/types_test.go
+++ b/types_test.go
@@ -38,3 +38,83 @@ func TestMakeGoLangScanType(t *testing.T) {
 		t.Errorf("invalid type returned for typeIntN")
 	}
 }
+
+func TestMakeGoLangTypeName(t *testing.T) {
+	defer handlePanic(t)
+
+	tests := []struct {
+		typeName   string
+		typeString string
+		typeID     uint8
+	}{
+		{"typeDateTime", "DATETIME", typeDateTime},
+		{"typeDateTim4", "SMALLDATETIME", typeDateTim4},
+		{"typeBigBinary", "BINARY", typeBigBinary},
+		//TODO: Add other supported types
+	}
+
+	for _, tt := range tests {
+		if makeGoLangTypeName(typeInfo{TypeId: tt.typeID}) != tt.typeString {
+			t.Errorf("invalid type name returned for %s", tt.typeName)
+		}
+	}
+}
+
+func TestMakeGoLangTypeLength(t *testing.T) {
+	defer handlePanic(t)
+
+	tests := []struct {
+		typeName   string
+		typeVarLen bool
+		typeLen    int64
+		typeID     uint8
+	}{
+		{"typeDateTime", false, 0, typeDateTime},
+		{"typeDateTim4", false, 0, typeDateTim4},
+		{"typeBigBinary", false, 0, typeBigBinary},
+		//TODO: Add other supported types
+	}
+
+	for _, tt := range tests {
+		n, v := makeGoLangTypeLength(typeInfo{TypeId: tt.typeID})
+		if v != tt.typeVarLen {
+			t.Errorf("invalid type length variability returned for %s", tt.typeName)
+		}
+		if n != tt.typeLen {
+			t.Errorf("invalid type length returned for %s", tt.typeName)
+		}
+	}
+}
+
+func TestMakeGoLangTypePrecisionScale(t *testing.T) {
+	defer handlePanic(t)
+
+	tests := []struct {
+		typeName   string
+		typeID     uint8
+		typeVarLen bool
+		typePrec   int64
+		typeScale  int64
+	}{
+		{"typeDateTime", typeDateTime, false, 0, 0},
+		{"typeDateTim4", typeDateTim4, false, 0, 0},
+		{"typeBigBinary", typeBigBinary, false, 0, 0},
+		//TODO: Add other supported types
+	}
+
+	for _, tt := range tests {
+		prec, scale, varLen := makeGoLangTypePrecisionScale(typeInfo{TypeId: tt.typeID})
+		if varLen != tt.typeVarLen {
+			t.Errorf("invalid type length variability returned for %s", tt.typeName)
+		}
+		if prec != tt.typePrec || scale != tt.typeScale {
+			t.Errorf("invalid type precision and/or scale returned for %s", tt.typeName)
+		}
+	}
+}
+
+func handlePanic(t *testing.T) {
+	if r := recover(); r != nil {
+		t.Errorf("recovered panic")
+	}
+}


### PR DESCRIPTION
I found two more column data types that weren't fully supported in the makeGoLangScanType func and associated switch statements, which result in panics.

SMALLDATETIME NOT NULL and DATETIME NOT NULL