### PR TITLE
mssql: de-couple the packet size from the buffer size

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -24,16 +24,20 @@ type header struct {
 type tdsBuffer struct {
 	transport io.ReadWriteCloser
 
+	packetSize int
+
 	// Write fields.
-	wbuf []byte
-	wpos uint16
+	wbuf        []byte
+	wpos        int
+	wPacketSeq  byte
+	wPacketType packetType
 
 	// Read fields.
 	rbuf        []byte
-	rpos        uint16
-	rsize       uint16
+	rpos        int
+	rsize       int
 	final       bool
-	packet_type packetType
+	rPacketType packetType
 
 	// afterFirst is assigned to right after tdsBuffer is created and
 	// before the first use. It is executed after the first packet is
@@ -42,40 +46,36 @@ type tdsBuffer struct {
 }
 
 func newTdsBuffer(bufsize uint16, transport io.ReadWriteCloser) *tdsBuffer {
-	w := new(tdsBuffer)
-	w.wbuf = make([]byte, bufsize)
-	w.rbuf = make([]byte, bufsize)
-	w.wpos = 0
-	w.rpos = 8
-	w.transport = transport
-	return w
-}
-
-func (rw *tdsBuffer) ResizeBuffer(packetsizei int) {
-	if len(rw.rbuf) != packetsizei {
-		newbuf := make([]byte, packetsizei)
-		copy(newbuf, rw.rbuf)
-		rw.rbuf = newbuf
-	}
-	if len(rw.wbuf) != packetsizei {
-		newbuf := make([]byte, packetsizei)
-		copy(newbuf, rw.wbuf)
-		rw.wbuf = newbuf
+	return &tdsBuffer{
+		packetSize: int(bufsize),
+		wbuf:       make([]byte, 1<<16),
+		rbuf:       make([]byte, 1<<16),
+		rpos:       8,
+		transport:  transport,
 	}
 }
 
-func (w *tdsBuffer) PackageSize() uint32 {
-	return uint32(len(w.wbuf))
+func (rw *tdsBuffer) ResizeBuffer(packetSize int) {
+	rw.packetSize = packetSize
+}
+
+func (w *tdsBuffer) PackageSize() int {
+	return w.packetSize
 }
 
 func (w *tdsBuffer) flush() (err error) {
 	// Write packet size.
-	binary.BigEndian.PutUint16(w.wbuf[2:], w.wpos)
+	w.wbuf[0] = byte(w.wPacketType)
+	binary.BigEndian.PutUint16(w.wbuf[2:], uint16(w.wpos))
+	w.wbuf[6] = w.wPacketSeq
 
 	// Write packet into underlying transport.
 	if _, err = w.transport.Write(w.wbuf[:w.wpos]); err != nil {
 		return err
 	}
+	// It is possible to create a whole new buffer after a flush.
+	// Useful for debugging. Normally reuse the buffer.
+	// w.wbuf = make([]byte, 1<<16)
 
 	// Execute afterFirst hook if it is set.
 	if w.afterFirst != nil {
@@ -84,19 +84,17 @@ func (w *tdsBuffer) flush() (err error) {
 	}
 
 	w.wpos = 8
-	// packet number
-	w.wbuf[6] += 1
+	w.wPacketSeq++
 	return nil
 }
 
 func (w *tdsBuffer) Write(p []byte) (total int, err error) {
-	total = 0
 	for {
-		copied := copy(w.wbuf[w.wpos:], p)
-		w.wpos += uint16(copied)
+		copied := copy(w.wbuf[w.wpos:w.packetSize], p)
+		w.wpos += copied
 		total += copied
 		if copied == len(p) {
-			break
+			return
 		}
 		if err = w.flush(); err != nil {
 			return
@@ -117,43 +115,41 @@ func (w *tdsBuffer) WriteByte(b byte) error {
 	return nil
 }
 
-func (w *tdsBuffer) BeginPacket(packet_type packetType) {
-	w.wbuf[0] = byte(packet_type)
-	w.wbuf[1] = 0 // packet is incomplete
-	w.wbuf[4] = 0 // spid
-	w.wbuf[5] = 0
-	w.wbuf[6] = 1 // packet id
-	w.wbuf[7] = 0 // window
+func (w *tdsBuffer) BeginPacket(packetType packetType) {
+	w.wbuf[1] = 0 // Packet is incomplete. This byte is set again in FinishPacket.
 	w.wpos = 8
+	w.wPacketSeq = 1
+	w.wPacketType = packetType
 }
 
 func (w *tdsBuffer) FinishPacket() error {
-	w.wbuf[1] = 1 // this is last packet
+	w.wbuf[1] = 1 // Mark this as the last packet in the message.
 	return w.flush()
 }
 
+var headerSize = binary.Size(header{})
+
 func (r *tdsBuffer) readNextPacket() error {
-	header := header{}
+	h := header{}
 	var err error
-	err = binary.Read(r.transport, binary.BigEndian, &header)
+	err = binary.Read(r.transport, binary.BigEndian, &h)
 	if err != nil {
 		return err
 	}
-	offset := uint16(binary.Size(header))
-	if int(header.Size) > len(r.rbuf) {
+	if int(h.Size) > len(r.rbuf) {
 		return errors.New("Invalid packet size, it is longer than buffer size")
 	}
-	if int(offset) > int(header.Size) {
+	if headerSize > int(h.Size) {
 		return errors.New("Invalid packet size, it is shorter than header size")
 	}
-	_, err = io.ReadFull(r.transport, r.rbuf[offset:header.Size])
+	_, err = io.ReadFull(r.transport, r.rbuf[headerSize:h.Size])
 	if err != nil {
 		return err
 	}
-	r.rpos = offset
-	r.rsize = header.Size
-	r.final = header.Status != 0
-	r.packet_type = header.PacketType
+	r.rpos = headerSize
+	r.rsize = int(h.Size)
+	r.final = h.Status != 0
+	r.rPacketType = h.PacketType
 	return nil
 }
 
@@ -162,7 +158,7 @@ func (r *tdsBuffer) BeginRead() (packetType, error) {
 	if err != nil {
 		return 0, err
 	}
-	return r.packet_type, nil
+	return r.rPacketType, nil
 }
 
 func (r *tdsBuffer) ReadByte() (res byte, err error) {
@@ -250,6 +246,6 @@ func (r *tdsBuffer) Read(buf []byte) (copied int, err error) {
 		}
 	}
 	copied = copy(buf, r.rbuf[r.rpos:r.rsize])
-	r.rpos += uint16(copied)
+	r.rpos += copied
 	return
 }

--- a/buf_test.go
+++ b/buf_test.go
@@ -190,6 +190,6 @@ func TestWrite(t *testing.T) {
 		2, 1, 0, 9, 0, 0, 2, 0, 6, // packet 3
 	}
 	if bytes.Compare(memBuf.Bytes(), expectedBuf) != 0 {
-		t.Fatalf("Written buffer has invalid content: %v", memBuf.Bytes())
+		t.Fatalf("Written buffer has invalid content:\n got: %v\nwant: %v", memBuf.Bytes(), expectedBuf)
 	}
 }

--- a/mssql.go
+++ b/mssql.go
@@ -313,8 +313,15 @@ func (s *MssqlStmt) sendQuery(args []namedValue) (err error) {
 	}
 
 	if s.notifSub != nil {
-		headers = append(headers, headerStruct{hdrtype: dataStmHdrQueryNotif,
-			data: queryNotifHdr{s.notifSub.msgText, s.notifSub.options, s.notifSub.timeout}.pack()})
+		headers = append(headers,
+			headerStruct{
+				hdrtype: dataStmHdrQueryNotif,
+				data: queryNotifHdr{
+					s.notifSub.msgText,
+					s.notifSub.options,
+					s.notifSub.timeout,
+				}.pack(),
+			})
 	}
 
 	// no need to check number of parameters here, it is checked by database/sql

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -375,9 +375,9 @@ with
 				rows, err := r.conn.QueryContext(ctx, query)
 				if err != nil {
 					if r.pass {
-						t.Error("QueryContext", len(query), err)
+						t.Errorf("QueryContext: %+v", err)
 					} else {
-						t.Log("QueryContext", len(query), err)
+						t.Logf("QueryContext: %+v", err)
 					}
 					return
 				}

--- a/tds.go
+++ b/tds.go
@@ -631,9 +631,7 @@ func writeAllHeaders(w io.Writer, headers []headerStruct) (err error) {
 	return nil
 }
 
-func sendSqlBatch72(buf *tdsBuffer,
-	sqltext string,
-	headers []headerStruct) (err error) {
+func sendSqlBatch72(buf *tdsBuffer, sqltext string, headers []headerStruct) (err error) {
 	buf.BeginPacket(packSQLBatch)
 
 	if err = writeAllHeaders(buf, headers); err != nil {
@@ -1282,7 +1280,7 @@ initiate_connection:
 
 	login := login{
 		TDSVersion:   verTDS74,
-		PacketSize:   outbuf.PackageSize(),
+		PacketSize:   uint32(outbuf.PackageSize()),
 		Database:     p.database,
 		OptionFlags2: fODBC, // to get unlimited TEXTSIZE
 		HostName:     p.workstation,


### PR DESCRIPTION
If the packet size is set too small, the read buffer size will
overflow. Prevent this by setting the buffer size independent of the
packet size.

For #166