### PR TITLE
Support the datetime type from MSSQL Server 2008

### DIFF
--- a/types.go
+++ b/types.go
@@ -1143,6 +1143,10 @@ func makeGoLangTypeName(ti typeInfo) string {
 		default:
 			panic("invalid size of MONEYN")
 		}
+	case typeDateTim4:
+		return "SMALLDATETIME"
+	case typeDateTime:
+		return "DATETIME"
 	case typeDateTimeN:
 		switch ti.Size {
 		case 4:
@@ -1244,6 +1248,10 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		default:
 			panic("invalid size of MONEYN")
 		}
+	case typeDateTim4:
+		return 0, false
+	case typeDateTime:
+		return 0, false
 	case typeDateTimeN:
 		switch ti.Size {
 		case 4:
@@ -1363,6 +1371,10 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		default:
 			panic("invalid size of MONEYN")
 		}
+	case typeDateTim4:
+		return 0, 0, false
+	case typeDateTime:
+		return 0, 0, false
 	case typeDateTimeN:
 		switch ti.Size {
 		case 4:


### PR DESCRIPTION
I was using this library to work with an old MSSQL server for a few days, and I got the following error: `not implemented makeDecl for type 61`.

It looked like https://github.com/denisenkom/go-mssqldb/issues/279 

I no longer have a Microsoft Server I can work with, but it might be related to this specific version of MSSQL (MSSQL Server 2008 R2).