### PR TITLE
fix #166: Azure SQL long query: driver: bad connection

### DIFF
--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -362,7 +362,7 @@ with
 	// Use separate Conns from the connection pool to ensure separation.
 	runs := []*run{
 		{name: "rev", pings: []int{4, 1}, pass: true},
-		{name: "forward", pings: []int{1}, pass: false},
+		{name: "forward", pings: []int{1}, pass: true},
 	}
 	for _, r := range runs {
 		var err error

--- a/tds.go
+++ b/tds.go
@@ -1260,6 +1260,11 @@ initiate_connection:
 			config.InsecureSkipVerify = true
 		}
 		config.ServerName = p.hostInCertificate
+		// fix for https://github.com/denisenkom/go-mssqldb/issues/166
+		// Go implementation of TLS payload size heuristic algorithm splits single TDS package to multiple TCP segments,
+		// while SQL Server seems to expect one TCP segment per encrypted TDS package.
+		// Setting DynamicRecordSizingDisabled to true disables that algorithm and uses 16384 bytes per TLS package
+		config.DynamicRecordSizingDisabled = true
 		outbuf.transport = conn
 		toconn.buf = outbuf
 		tlsConn := tls.Client(toconn, &config)


### PR DESCRIPTION
This is what I found regarding https://github.com/denisenkom/go-mssqldb/issues/166:
Microsoft Message Analyzer shows that Go tls uses heuristic algorithm to determine TLS payload size, which produces splitting multiple TCP segments for for large TDS packets of SQL queries over 2326 bytes, while SQL Server seems to expect one TCP segment per TDS packet.

Disabling the algorithm mentioned above (could be found in Conn.maxPayloadSizeForWrite of crypto/tls package) fixes the issue.