### PR TITLE
Fix `rows.ColumnTypes()`  for money not null type

### DIFF
--- a/types.go
+++ b/types.go
@@ -922,7 +922,7 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 		return reflect.TypeOf(true)
 	case typeDecimalN, typeNumericN:
 		return reflect.TypeOf([]byte{})
-	case typeMoneyN:
+	case typeMoney, typeMoney4, typeMoneyN:
 		switch ti.Size {
 		case 4:
 			return reflect.TypeOf([]byte{})
@@ -1140,7 +1140,7 @@ func makeGoLangTypeName(ti typeInfo) string {
 		return "BIT"
 	case typeDecimalN, typeNumericN:
 		return "DECIMAL"
-	case typeMoneyN:
+	case typeMoney, typeMoney4, typeMoneyN:
 		switch ti.Size {
 		case 4:
 			return "SMALLMONEY"
@@ -1247,7 +1247,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		return 0, false
 	case typeDecimalN, typeNumericN:
 		return 0, false
-	case typeMoneyN:
+	case typeMoney, typeMoney4, typeMoneyN:
 		switch ti.Size {
 		case 4:
 			return 0, false
@@ -1370,7 +1370,7 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		return 0, 0, false
 	case typeDecimalN, typeNumericN:
 		return int64(ti.Prec), int64(ti.Scale), true
-	case typeMoneyN:
+	case typeMoney, typeMoney4, typeMoneyN:
 		switch ti.Size {
 		case 4:
 			return 0, 0, false

--- a/types_test.go
+++ b/types_test.go
@@ -37,6 +37,9 @@ func TestMakeGoLangScanType(t *testing.T) {
 	if (reflect.TypeOf(int64(0)) != makeGoLangScanType(typeInfo{TypeId: typeIntN, Size: 4})) {
 		t.Errorf("invalid type returned for typeIntN")
 	}
+	if (reflect.TypeOf([]byte{}) != makeGoLangScanType(typeInfo{TypeId: typeMoney, Size: 8})) {
+		t.Errorf("invalid type returned for typeIntN")
+	}
 }
 
 func TestMakeGoLangTypeName(t *testing.T) {


### PR DESCRIPTION
Given a database table:

    create table test_table(m money not null)

the statements

    rows, _ := db.Query("SELECT * FROM test_table6")
    cols, _ := rows.ColumnTypes()

panic with:

    panic: not implemented makeDecl for type 60
    
    goroutine 1 [running]:
    github.com/denisenkom/go-mssqldb.makeGoLangScanType(0x3c, 0x8, 0x0, 0xc42001ee30, 0x8, 0x8, 0x0, 0x0, 0x0, 0x0, ...)
    /home/paul/gocode/src/github.com/denisenkom/go-mssqldb/types.go:976 +0x1359
    github.com/denisenkom/go-mssqldb.(*MssqlRows).ColumnTypeScanType(0xc420082870, 0x0, 0xc420082870, 0x7f977af93188)
    /home/paul/gocode/src/github.com/denisenkom/go-mssqldb/mssql.go:586 +0x73
    database/sql.rowsColumnInfoSetup(0x7f8000, 0xc420082870, 0xc4200da4b0, 0x5d6843, 0xc420299ec0)
    /usr/local/go/src/database/sql/sql.go:2641 +0x17b

because `makeGoLangScanType` and others do not have a case clause matching `money`.

This pull request has 2 commits:

* 851517d3a9369cc8286f8246332d4d56d2a3ace6 which adds a failing test for the problem.
* c8666519f6cb8b64dc45da76e9e0327764149b41 which adds a fix for the panic.