### PR TITLE
Fix tests for Go 1.10

### DIFF
--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -114,7 +114,7 @@ func TestHasPrefixFold(t *testing.T) {
 	for _, item := range list {
 		is := hasPrefixFold(item.s, item.pre)
 		if is != item.is {
-			t.Error("want (%q, %q)=%t got %t", item.s, item.pre, item.is, is)
+			t.Errorf("want (%q, %q)=%t got %t", item.s, item.pre, item.is, is)
 		}
 	}
 }

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -598,7 +598,7 @@ func (b *MssqlBulk) makeParam(val DataValue, col columnStruct) (res Param, err e
 			res.ti.Size = len(val)
 			res.buffer = val
 		default:
-			err = fmt.Errorf("mssql: invalid type for Guid column", val)
+			err = fmt.Errorf("mssql: invalid type for Guid column: %s", val)
 			return
 		}
 


### PR DESCRIPTION
I maintain the Fedora package of go-mssqldb, and the recent update to go 1.10 (slated to appear in Fedora 28) triggered a couple of test failures due to `go vet` being [run by default now](https://golang.org/doc/go1.10#test). It looks like you'd already made an earlier pass for this a few commits back; this patch just grabs a couple of stragglers.