### PR TITLE
mssql: support the connection session resetter interface

### DIFF
--- a/buf_test.go
+++ b/buf_test.go
@@ -151,7 +151,7 @@ func TestReadFailsOnSecondPacket(t *testing.T) {
 func TestWrite(t *testing.T) {
 	memBuf := bytes.NewBuffer([]byte{})
 	buf := newTdsBuffer(11, closableBuffer{memBuf})
-	buf.BeginPacket(1)
+	buf.BeginPacket(1, false)
 	err := buf.WriteByte(2)
 	if err != nil {
 		t.Fatal("WriteByte failed:", err.Error())
@@ -172,7 +172,7 @@ func TestWrite(t *testing.T) {
 		t.Fatalf("Written buffer has invalid content: %v", memBuf.Bytes())
 	}
 
-	buf.BeginPacket(2)
+	buf.BeginPacket(2, false)
 	wrote, err = buf.Write([]byte{3, 4, 5, 6})
 	if err != nil {
 		t.Fatal("Write failed:", err.Error())

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -128,7 +128,7 @@ func (b *Bulk) sendBulkCommand() (err error) {
 	b.headerSent = true
 
 	var buf = b.cn.sess.buf
-	buf.BeginPacket(packBulkLoadBCP)
+	buf.BeginPacket(packBulkLoadBCP, false)
 
 	// send the columns metadata
 	columnMetadata := b.createColMetadata()

--- a/mssql_go110.go
+++ b/mssql_go110.go
@@ -1,0 +1,10 @@
+// +build go1.10
+
+package mssql
+
+import (
+	"database/sql/driver"
+)
+
+var _ driver.Connector = &Connector{}
+var _ driver.SessionResetter = &Conn{}

--- a/net.go
+++ b/net.go
@@ -58,7 +58,7 @@ func (c *timeoutConn) Read(b []byte) (n int, err error) {
 func (c *timeoutConn) Write(b []byte) (n int, err error) {
 	if c.buf != nil {
 		if !c.packetPending {
-			c.buf.BeginPacket(packPrelogin)
+			c.buf.BeginPacket(packPrelogin, false)
 			c.packetPending = true
 		}
 		n, err = c.buf.Write(b)

--- a/rpc.go
+++ b/rpc.go
@@ -57,8 +57,8 @@ var (
 )
 
 // http://msdn.microsoft.com/en-us/library/dd357576.aspx
-func sendRpc(buf *tdsBuffer, headers []headerStruct, proc ProcId, flags uint16, params []Param) (err error) {
-	buf.BeginPacket(packRPCRequest)
+func sendRpc(buf *tdsBuffer, headers []headerStruct, proc ProcId, flags uint16, params []Param, resetSession bool) (err error) {
+	buf.BeginPacket(packRPCRequest, resetSession)
 	writeAllHeaders(buf, headers)
 	if len(proc.name) == 0 {
 		var idswitch uint16 = 0xffff

--- a/tds.go
+++ b/tds.go
@@ -162,7 +162,7 @@ func (p KeySlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 func writePrelogin(w *tdsBuffer, fields map[uint8][]byte) error {
 	var err error
 
-	w.BeginPacket(packPrelogin)
+	w.BeginPacket(packPrelogin, false)
 	offset := uint16(5*len(fields) + 1)
 	keys := make(KeySlice, 0, len(fields))
 	for k, _ := range fields {
@@ -352,7 +352,7 @@ func manglePassword(password string) []byte {
 
 // http://msdn.microsoft.com/en-us/library/dd304019.aspx
 func sendLogin(w *tdsBuffer, login login) error {
-	w.BeginPacket(packLogin7)
+	w.BeginPacket(packLogin7, false)
 	hostname := str2ucs2(login.HostName)
 	username := str2ucs2(login.UserName)
 	password := manglePassword(login.Password)
@@ -633,8 +633,8 @@ func writeAllHeaders(w io.Writer, headers []headerStruct) (err error) {
 	return nil
 }
 
-func sendSqlBatch72(buf *tdsBuffer, sqltext string, headers []headerStruct) (err error) {
-	buf.BeginPacket(packSQLBatch)
+func sendSqlBatch72(buf *tdsBuffer, sqltext string, headers []headerStruct, resetSession bool) (err error) {
+	buf.BeginPacket(packSQLBatch, resetSession)
 
 	if err = writeAllHeaders(buf, headers); err != nil {
 		return
@@ -650,7 +650,7 @@ func sendSqlBatch72(buf *tdsBuffer, sqltext string, headers []headerStruct) (err
 // 2.2.1.7 Attention: https://msdn.microsoft.com/en-us/library/dd341449.aspx
 // 4.19.2 Out-of-Band Attention Signal: https://msdn.microsoft.com/en-us/library/dd305167.aspx
 func sendAttention(buf *tdsBuffer) error {
-	buf.BeginPacket(packAttention)
+	buf.BeginPacket(packAttention, false)
 	return buf.FinishPacket()
 }
 
@@ -1337,7 +1337,7 @@ continue_login:
 		}
 	}
 	if sspi_msg != nil {
-		outbuf.BeginPacket(packSSPIMessage)
+		outbuf.BeginPacket(packSSPIMessage, false)
 		_, err = outbuf.Write(sspi_msg)
 		if err != nil {
 			return nil, err

--- a/tds_test.go
+++ b/tds_test.go
@@ -89,7 +89,7 @@ func TestSendSqlBatch(t *testing.T) {
 		{hdrtype: dataStmHdrTransDescr,
 			data: transDescrHdr{0, 1}.pack()},
 	}
-	err = sendSqlBatch72(conn.buf, "select 1", headers)
+	err = sendSqlBatch72(conn.buf, "select 1", headers, true)
 	if err != nil {
 		t.Error("Sending sql batch failed", err.Error())
 		return

--- a/tran.go
+++ b/tran.go
@@ -28,9 +28,8 @@ const (
 	isolationSnapshot                = 5
 )
 
-func sendBeginXact(buf *tdsBuffer, headers []headerStruct, isolation isoLevel,
-	name string) (err error) {
-	buf.BeginPacket(packTransMgrReq)
+func sendBeginXact(buf *tdsBuffer, headers []headerStruct, isolation isoLevel, name string, resetSession bool) (err error) {
+	buf.BeginPacket(packTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmBeginXact
 	err = binary.Write(buf, binary.LittleEndian, &rqtype)
@@ -52,8 +51,8 @@ const (
 	fBeginXact = 1
 )
 
-func sendCommitXact(buf *tdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string) error {
-	buf.BeginPacket(packTransMgrReq)
+func sendCommitXact(buf *tdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
+	buf.BeginPacket(packTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmCommitXact
 	err := binary.Write(buf, binary.LittleEndian, &rqtype)
@@ -81,8 +80,8 @@ func sendCommitXact(buf *tdsBuffer, headers []headerStruct, name string, flags u
 	return buf.FinishPacket()
 }
 
-func sendRollbackXact(buf *tdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string) error {
-	buf.BeginPacket(packTransMgrReq)
+func sendRollbackXact(buf *tdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
+	buf.BeginPacket(packTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmRollbackXact
 	err := binary.Write(buf, binary.LittleEndian, &rqtype)


### PR DESCRIPTION
The bulk table load uses a per-session temp table. Pull
out a single connection to fix the test.

Fixes #329