### PR TITLE
mssql: default to no connection time, use context.Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Other supported formats are listed below.
 * `user id` - enter the SQL Server Authentication user id or the Windows Authentication user id in the DOMAIN\User format. On Windows, if user id is empty or missing Single-Sign-On is used.
 * `password`
 * `database`
-* `connection timeout` - in seconds (default is 30), set to 0 for no timeout. Recommended to set to 0 and use context to manage query and connection timeouts.
+* `connection timeout` - in seconds (default is 0 for no timeout), set to 0 for no timeout. Recommended to set to 0 and use context to manage query and connection timeouts.
 * `dial timeout` - in seconds (default is 15), set to 0 for no timeout
 * `encrypt`
   * `disable` - Data send between client and server is not encrypted.
@@ -75,7 +75,7 @@ Other supported formats are listed below.
 
 ```go
   query := url.Values{}
-  query.Add("connection timeout", "30")
+  query.Add("app name", "MyAppName")
 
   u := &url.URL{
       Scheme:   "sqlserver",
@@ -90,14 +90,14 @@ Other supported formats are listed below.
 2. ADO: `key=value` pairs separated by `;`. Values may not contain `;`, leading and trailing whitespace is ignored.
      Examples:
 	
-  * `server=localhost\\SQLExpress;user id=sa;database=master;connection timeout=30`
-  * `server=localhost;user id=sa;database=master;connection timeout=30`
+  * `server=localhost\\SQLExpress;user id=sa;database=master;app name=MyAppName`
+  * `server=localhost;user id=sa;database=master;app name=MyAppName`
 
 3. ODBC: Prefix with `odbc`, `key=value` pairs separated by `;`. Allow `;` by wrapping
     values in `{}`. Examples:
 	
-  * `odbc:server=localhost\\SQLExpress;user id=sa;database=master;connection timeout=30`
-  * `odbc:server=localhost;user id=sa;database=master;connection timeout=30`
+  * `odbc:server=localhost\\SQLExpress;user id=sa;database=master;app name=MyAppName`
+  * `odbc:server=localhost;user id=sa;database=master;app name=MyAppName`
   * `odbc:server=localhost;user id=sa;password={foo;bar}` // Value marked with `{}`, password is "foo;bar"
   * `odbc:server=localhost;user id=sa;password={foo{bar}` // Value marked with `{}`, password is "foo{bar"
   * `odbc:server=localhost;user id=sa;password={foobar }` // Value marked with `{}`, password is "foobar "

--- a/tds.go
+++ b/tds.go
@@ -993,10 +993,10 @@ func parseConnectParams(dsn string) (connectParams, error) {
 	}
 
 	// https://msdn.microsoft.com/en-us/library/dd341108.aspx
-	p.dial_timeout = 15 * time.Second
-	p.conn_timeout = 30 * time.Second
-	strconntimeout, ok := params["connection timeout"]
-	if ok {
+	//
+	// Do not set a connection timeout. Use Context to manage such things.
+	// Default to zero, but still allow it to be set.
+	if strconntimeout, ok := params["connection timeout"]; ok {
 		timeout, err := strconv.ParseUint(strconntimeout, 10, 64)
 		if err != nil {
 			f := "Invalid connection timeout '%v': %v"
@@ -1004,8 +1004,8 @@ func parseConnectParams(dsn string) (connectParams, error) {
 		}
 		p.conn_timeout = time.Duration(timeout) * time.Second
 	}
-	strdialtimeout, ok := params["dial timeout"]
-	if ok {
+	p.dial_timeout = 15 * time.Second
+	if strdialtimeout, ok := params["dial timeout"]; ok {
 		timeout, err := strconv.ParseUint(strdialtimeout, 10, 64)
 		if err != nil {
 			f := "Invalid dial timeout '%v': %v"
@@ -1017,7 +1017,6 @@ func parseConnectParams(dsn string) (connectParams, error) {
 	// default keep alive should be 30 seconds according to spec:
 	// https://msdn.microsoft.com/en-us/library/dd341108.aspx
 	p.keepAlive = 30 * time.Second
-
 	if keepAlive, ok := params["keepalive"]; ok {
 		timeout, err := strconv.ParseUint(keepAlive, 10, 64)
 		if err != nil {


### PR DESCRIPTION
I think we should not use a connection time default. This has confused many people. I'm not even sure the setting means the same thing in SQL Server driver. In this driver it sets the response deadline after a packet has been set, effectively setting the query timeout.
