### PR TITLE
queries: use reflect to support other in-out value types

### DIFF
--- a/mssql_go19pre.go
+++ b/mssql_go19pre.go
@@ -10,3 +10,7 @@ import (
 func (s *Stmt) makeParamExtra(val driver.Value) (param, error) {
 	return param{}, fmt.Errorf("mssql: unknown type for %T", val)
 }
+
+func scanIntoOut(name string, fromServer, scanInto interface{}) error {
+	return fmt.Errorf("mssql: unsupported OUTPUT type, use a newer Go version")
+}

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -67,10 +67,15 @@ func TestOutputINOUTParam(t *testing.T) {
 CREATE PROCEDURE abinout
    @aid INT,
    @bid INT OUTPUT,
-   @cstr NVARCHAR(2000) OUTPUT
+   @cstr NVARCHAR(2000) OUTPUT,
+   @vout VARCHAR(2000) OUTPUT
 AS
 BEGIN
-   SELECT @bid = @aid + @bid, @cstr = 'OK';
+   SELECT
+		@bid = @aid + @bid,
+		@cstr = 'OK',
+		@Vout = 'DREAM'
+	;
 END;
 `
 	sqltextdrop := `DROP PROCEDURE abinout;`
@@ -95,10 +100,12 @@ END;
 	}
 	var bout int64 = 3
 	var cout string
+	var vout VarChar
 	_, err = db.ExecContext(ctx, sqltextrun,
 		sql.Named("aid", 5),
 		sql.Named("bid", sql.Out{Dest: &bout}),
 		sql.Named("cstr", sql.Out{Dest: &cout}),
+		sql.Named("vout", sql.Out{Dest: &vout}),
 	)
 	defer db.ExecContext(ctx, sqltextdrop)
 	if err != nil {
@@ -111,6 +118,9 @@ END;
 
 	if cout != "OK" {
 		t.Errorf("expected OK, got %s", cout)
+	}
+	if string(vout) != "DREAM" {
+		t.Errorf("expected DREAM, got %s", vout)
 	}
 }
 

--- a/token.go
+++ b/token.go
@@ -640,7 +640,7 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[strin
 			if len(nv.Name) > 0 {
 				name := nv.Name[1:] // Remove the leading "@".
 				if ov, has := outs[name]; has {
-					err = scanIntoOut(nv.Value, ov)
+					err = scanIntoOut(name, nv.Value, ov)
 					if err != nil {
 						fmt.Println("scan error", err)
 						ch <- err
@@ -651,28 +651,6 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[strin
 			badStreamPanic(fmt.Errorf("unknown token type returned: %v", token))
 		}
 	}
-}
-
-func scanIntoOut(fromServer, scanInto interface{}) error {
-	switch fs := fromServer.(type) {
-	case int64:
-		switch si := scanInto.(type) {
-		case *int64:
-			*si = fs
-		default:
-			return fmt.Errorf("unsupported scan into type %[1]T for server type %[2]T", scanInto, fromServer)
-		}
-		return nil
-	case string:
-		switch si := scanInto.(type) {
-		case *string:
-			*si = fs
-		default:
-			return fmt.Errorf("unsupported scan into type %[1]T for server type %[2]T", scanInto, fromServer)
-		}
-		return nil
-	}
-	return fmt.Errorf("unsupported type from server %[1]T=%[1]v", fromServer)
 }
 
 type parseRespIter byte


### PR DESCRIPTION
Fixes #382