### PR TITLE
fix #370: bulkcopy: slice bounds out of range

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -105,7 +105,7 @@ func (w *tdsBuffer) Write(p []byte) (total int, err error) {
 }
 
 func (w *tdsBuffer) WriteByte(b byte) error {
-	if int(w.wpos) == len(w.wbuf) {
+	if int(w.wpos) == len(w.wbuf) || w.wpos == w.packetSize {
 		if err := w.flush(); err != nil {
 			return err
 		}

--- a/buf_test.go
+++ b/buf_test.go
@@ -193,3 +193,27 @@ func TestWrite(t *testing.T) {
 		t.Fatalf("Written buffer has invalid content:\n got: %v\nwant: %v", memBuf.Bytes(), expectedBuf)
 	}
 }
+
+func TestWrite_BufferBounds(t *testing.T) {
+	memBuf := bytes.NewBuffer([]byte{})
+	buf := newTdsBuffer(11, closableBuffer{memBuf})
+
+	buf.BeginPacket(1, false)
+	// write bytes enough to complete a package
+	_, err := buf.Write([]byte{1,1,1})
+	if err != nil {
+		t.Fatal("Write failed:", err.Error())
+	}
+	err = buf.WriteByte(1)
+	if err != nil {
+		t.Fatal("WriteByte failed:", err.Error())
+	}
+	_,err = buf.Write([]byte{1,1,1})
+	if err != nil {
+		t.Fatal("Write failed:", err.Error())
+	}
+	err = buf.FinishPacket()
+	if err != nil {
+		t.Fatal("FinishPacket failed:", err.Error())
+	}
+}


### PR DESCRIPTION
Fix for #370:
There are cases when we sequentially call buf.Write, buf.WriteByte, buf.Write. In some of such cases buf.WriteByte doesn't Flush which leads to panic about "slice bounds out of range" on following buf.Write:

1. buf.Write before: (wpos: 3666, packetSize:4096, data len: 430) after: (wpos: 4096, packetSize:4096)
2. buf.WriteByte before: (wpos: 4096, packetSize:4096) after: (wpos: 4097, packetSize:4096)
3. buf.Write: before: (wpos: **4097**, packetSize:4096, data len: 2)

Above the second call of buf.Write will try to slice wbuf with [4097:4096] which produces the panic.