### PR TITLE
Local time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # A pure Go MSSQL driver for Go's database/sql package
 
-[![GoDoc](https://godoc.org/github.com/denisenkom/go-mssqldb?status.svg)](http://godoc.org/github.com/denisenkom/go-mssqldb)
-[![Build status](https://ci.appveyor.com/api/projects/status/jrln8cs62wj9i0a2?svg=true)](https://ci.appveyor.com/project/denisenkom/go-mssqldb)
-[![codecov](https://codecov.io/gh/denisenkom/go-mssqldb/branch/master/graph/badge.svg)](https://codecov.io/gh/denisenkom/go-mssqldb)
+[![GoDoc](https://godoc.org/github.com/covrom/go-mssqldb?status.svg)](http://godoc.org/github.com/covrom/go-mssqldb)
+[![Build status](https://ci.appveyor.com/api/projects/status/jrln8cs62wj9i0a2?svg=true)](https://ci.appveyor.com/project/covrom/go-mssqldb)
+[![codecov](https://codecov.io/gh/covrom/go-mssqldb/branch/master/graph/badge.svg)](https://codecov.io/gh/covrom/go-mssqldb)
 
 ## Install
 
 Requires Go 1.8 or above.
 
-Install with `go get github.com/denisenkom/go-mssqldb` .
+Install with `go get github.com/covrom/go-mssqldb` .
 
 ## Connection Parameters and DSN
 
@@ -149,9 +149,9 @@ are supported:
 	or add a `select ID = convert(bigint, SCOPE_IDENTITY());` to the end of your
 	query (ref [SCOPE_IDENTITY](https://docs.microsoft.com/en-us/sql/t-sql/functions/scope-identity-transact-sql)).
 	This will ensure you are getting the correct ID and will prevent a network round trip.
- * [NewConnector](https://godoc.org/github.com/denisenkom/go-mssqldb#NewConnector)
+ * [NewConnector](https://godoc.org/github.com/covrom/go-mssqldb#NewConnector)
     may be used with [OpenDB](https://golang.org/pkg/database/sql/#OpenDB).
- * [Connector.SessionInitSQL](https://godoc.org/github.com/denisenkom/go-mssqldb#Connector.SessionInitSQL)
+ * [Connector.SessionInitSQL](https://godoc.org/github.com/covrom/go-mssqldb#Connector.SessionInitSQL)
 	may be set to set any driver specific session settings after the session
 	has been reset. If empty the session will still be reset but use the database
 	defaults in Go1.10+.

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -408,8 +408,7 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 		if val.(bool) {
 			res.buffer[0] = 1
 		}
-
-	case typeDateTime2N, typeDateTimeOffsetN:
+	case typeDateTime2N:
 		switch val := val.(type) {
 		case time.Time:
 			days, ns := dateTime2(val)
@@ -438,13 +437,47 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 			buf[res.ti.Size-2] = byte(days >> 8)
 			buf[res.ti.Size-1] = byte(days >> 16)
 
-			if col.ti.TypeId == typeDateTimeOffsetN {
-				_, offset := val.Zone()
-				var offsetMinute = uint16(offset / 60)
-				buf = append(buf, byte(offsetMinute))
-				buf = append(buf, byte(offsetMinute>>8))
-				res.ti.Size = res.ti.Size + 2
+			res.buffer = buf
+
+		default:
+			err = fmt.Errorf("mssql: invalid type for datetime2 column: %s", val)
+			return
+		}
+
+	case typeDateTimeOffsetN:
+		switch val := val.(type) {
+		case time.Time:
+			days, ns := dateTime2UTC(val)
+			ns /= int64(math.Pow10(int(col.ti.Scale)*-1) * 1000000000)
+
+			var data = make([]byte, 5)
+
+			data[0] = byte(ns)
+			data[1] = byte(ns >> 8)
+			data[2] = byte(ns >> 16)
+			data[3] = byte(ns >> 24)
+			data[4] = byte(ns >> 32)
+
+			if col.ti.Scale <= 2 {
+				res.ti.Size = 6
+			} else if col.ti.Scale <= 4 {
+				res.ti.Size = 7
+			} else {
+				res.ti.Size = 8
 			}
+			var buf []byte
+			buf = make([]byte, res.ti.Size)
+			copy(buf, data[0:res.ti.Size-3])
+
+			buf[res.ti.Size-3] = byte(days)
+			buf[res.ti.Size-2] = byte(days >> 8)
+			buf[res.ti.Size-1] = byte(days >> 16)
+
+			_, offset := val.Zone()
+			var offsetMinute = uint16(offset / 60)
+			buf = append(buf, byte(offsetMinute))
+			buf = append(buf, byte(offsetMinute>>8))
+			res.ti.Size = res.ti.Size + 2
 
 			res.buffer = buf
 

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -473,7 +473,7 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 				res.ti.Size = 4
 				res.buffer = make([]byte, 4)
 
-				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, val.Location())
 				dur := val.Sub(ref)
 				days := dur / (24 * time.Hour)
 				if days < 0 {
@@ -488,7 +488,7 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 				res.ti.Size = 8
 				res.buffer = make([]byte, 8)
 
-				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+				ref := time.Date(1900, 1, 1, 0, 0, 0, 0, val.Location())
 				dur := val.Sub(ref)
 				days := dur / (24 * time.Hour)
 				tm := (300 * (dur % (24 * time.Hour))) / time.Second

--- a/examples/bulk/bulk.go
+++ b/examples/bulk/bulk.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/denisenkom/go-mssqldb"
+	"github.com/covrom/go-mssqldb"
 )
 
 var (

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/covrom/go-mssqldb"
 )
 
 var (

--- a/examples/tsql/tsql.go
+++ b/examples/tsql/tsql.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/covrom/go-mssqldb"
 )
 
 func main() {

--- a/mssql.go
+++ b/mssql.go
@@ -769,7 +769,7 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 			res.ti.TypeId = typeDateTimeN
 			res.ti.Size = 8
 			res.buffer = make([]byte, 8)
-			ref := time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+			ref := time.Date(1900, 1, 1, 0, 0, 0, 0, val.Location())
 			dur := val.Sub(ref)
 			days := dur / (24 * time.Hour)
 			tm := (300 * (dur % (24 * time.Hour))) / time.Second

--- a/mssql.go
+++ b/mssql.go
@@ -751,7 +751,7 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 			res.ti.Size = 10
 			buf := make([]byte, 10)
 			res.buffer = buf
-			days, ns := dateTime2(val)
+			days, ns := dateTime2UTC(val)
 			ns /= 100
 			buf[0] = byte(ns)
 			buf[1] = byte(ns >> 8)

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -106,7 +106,7 @@ func (s *Stmt) makeParamExtra(val driver.Value) (res param, err error) {
 		res.ti.Size = 10
 		buf := make([]byte, 10)
 		res.buffer = buf
-		days, ns := dateTime2(t)
+		days, ns := dateTime2UTC(t)
 		ns /= 100
 		buf[0] = byte(ns)
 		buf[1] = byte(ns >> 8)

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -236,7 +236,7 @@ END;
 // config may help with that, but wireshark wasn't decrypting TDS based TLS streams
 // even when using that.
 //
-// Issue https://github.com/denisenkom/go-mssqldb/issues/166
+// Issue https://github.com/covrom/go-mssqldb/issues/166
 func TestTLSServerReadClose(t *testing.T) {
 	query := `
 with

--- a/queries_test.go
+++ b/queries_test.go
@@ -829,7 +829,7 @@ func TestStmt_SetQueryNotification(t *testing.T) {
 		rows.Close()
 	}
 	// notifications are sent to Service Broker
-	// see for more info: https://github.com/denisenkom/go-mssqldb/pull/90
+	// see for more info: https://github.com/covrom/go-mssqldb/pull/90
 }
 
 func TestErrorInfo(t *testing.T) {

--- a/tds.go
+++ b/tds.go
@@ -1268,7 +1268,7 @@ initiate_connection:
 			config.InsecureSkipVerify = true
 		}
 		config.ServerName = p.hostInCertificate
-		// fix for https://github.com/denisenkom/go-mssqldb/issues/166
+		// fix for https://github.com/covrom/go-mssqldb/issues/166
 		// Go implementation of TLS payload size heuristic algorithm splits single TDS package to multiple TCP segments,
 		// while SQL Server seems to expect one TCP segment per encrypted TDS package.
 		// Setting DynamicRecordSizingDisabled to true disables that algorithm and uses 16384 bytes per TLS package

--- a/types.go
+++ b/types.go
@@ -870,6 +870,18 @@ func dateTime2(t time.Time) (days int32, ns int64) {
 	return
 }
 
+func dateTime2UTC(t time.Time) (days int32, ns int64) {
+	// number of days since Jan 1 1970 UTC
+	days64 := divFloor(t.Unix(), 24*60*60)
+	// number of days since Jan 1 1 UTC
+	days = int32(days64) + 1969*365 + 1969/4 - 1969/100 + 1969/400
+	// number of seconds within day
+	secs := t.Unix() - days64*24*60*60
+	// number of nanoseconds within day
+	ns = secs*1e9 + int64(t.Nanosecond())
+	return
+}
+
 func decodeChar(col cp.Collation, buf []byte) string {
 	return cp.CharsetToUTF8(col, buf)
 }

--- a/types.go
+++ b/types.go
@@ -854,13 +854,19 @@ func divFloor(x int64, y int64) int64 {
 
 func dateTime2(t time.Time) (days int32, ns int64) {
 	// number of days since Jan 1 1970 UTC
-	days64 := divFloor(t.Unix(), 24*60*60)
-	// number of days since Jan 1 1 UTC
+	ref := time.Date(1970, 1, 1, 0, 0, 0, 0, t.Location())
+	dur := t.Sub(ref)
+	days64 := dur / (24 * time.Hour)
 	days = int32(days64) + 1969*365 + 1969/4 - 1969/100 + 1969/400
-	// number of seconds within day
-	secs := t.Unix() - days64*24*60*60
-	// number of nanoseconds within day
-	ns = secs*1e9 + int64(t.Nanosecond())
+	ns = int64(dur % (24 * time.Hour))
+
+	// days64 := divFloor(t.Unix(), 24*60*60)
+	// // number of days since Jan 1 1 UTC
+	// days = int32(days64) + 1969*365 + 1969/4 - 1969/100 + 1969/400
+	// // number of seconds within day
+	// secs := t.Unix() - days64*24*60*60
+	// // number of nanoseconds within day
+	// ns = secs*1e9 + int64(t.Nanosecond())
 	return
 }
 

--- a/types.go
+++ b/types.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/denisenkom/go-mssqldb/internal/cp"
+	"github.com/covrom/go-mssqldb/internal/cp"
 )
 
 // fixed-length data types

--- a/types.go
+++ b/types.go
@@ -242,7 +242,7 @@ func decodeDateTim4(buf []byte) time.Time {
 	days := binary.LittleEndian.Uint16(buf)
 	mins := binary.LittleEndian.Uint16(buf[2:])
 	return time.Date(1900, 1, 1+int(days),
-		0, int(mins), 0, 0, time.UTC)
+		0, int(mins), 0, 0, time.Local)
 }
 
 func decodeDateTime(buf []byte) time.Time {
@@ -251,7 +251,7 @@ func decodeDateTime(buf []byte) time.Time {
 	ns := int(math.Trunc(float64(tm%300)/0.3+0.5)) * 1000000
 	secs := int(tm / 300)
 	return time.Date(1900, 1, 1+int(days),
-		0, 0, secs, ns, time.UTC)
+		0, 0, secs, ns, time.Local)
 }
 
 func readFixedType(ti *typeInfo, r *tdsBuffer) interface{} {
@@ -802,7 +802,7 @@ func decodeDateInt(buf []byte) (days int) {
 }
 
 func decodeDate(buf []byte) time.Time {
-	return time.Date(1, 1, 1+decodeDateInt(buf), 0, 0, 0, 0, time.UTC)
+	return time.Date(1, 1, 1+decodeDateInt(buf), 0, 0, 0, 0, time.Local)
 }
 
 func decodeTimeInt(scale uint8, buf []byte) (sec int, ns int) {
@@ -822,14 +822,14 @@ func decodeTimeInt(scale uint8, buf []byte) (sec int, ns int) {
 
 func decodeTime(scale uint8, buf []byte) time.Time {
 	sec, ns := decodeTimeInt(scale, buf)
-	return time.Date(1, 1, 1, 0, 0, sec, ns, time.UTC)
+	return time.Date(1, 1, 1, 0, 0, sec, ns, time.Local)
 }
 
 func decodeDateTime2(scale uint8, buf []byte) time.Time {
 	timesize := len(buf) - 3
 	sec, ns := decodeTimeInt(scale, buf[:timesize])
 	days := decodeDateInt(buf[timesize:])
-	return time.Date(1, 1, 1+days, 0, 0, sec, ns, time.UTC)
+	return time.Date(1, 1, 1+days, 0, 0, sec, ns, time.Local)
 }
 
 func decodeDateTimeOffset(scale uint8, buf []byte) time.Time {


### PR DESCRIPTION
Change UTC datetime (without offset) to time.Time in time.Local zone for parsing result of queries and val.Location() for params.
UTC is wrong for non-UTC times and data in databases many times because servers (and go program) is in local timezone.