### PR TITLE
Type error with Go 1.11

### DIFF
--- a/token.go
+++ b/token.go
@@ -213,7 +213,7 @@ func processEnvChg(sess *tdsSession) {
 
 			// SQL Collation data should contain 5 bytes in length
 			if collationSize != 5 {
-				badStreamPanicf("Invalid SQL Collation size value returned from server: %s", collationSize)
+				badStreamPanicf("Invalid SQL Collation size value returned from server: %d", collationSize)
 			}
 
 			// 4 bytes, contains: LCID ColFlags Version


### PR DESCRIPTION
Building with Go 1.11 beta 2 in Fedora Rawhide threw a type error during a naive test run:

```
[...]
./token.go:216: badStreamPanicf format %s has arg collationSize of wrong type uint8                                                                                                                                
FAIL    github.com/denisenkom/go-mssqldb [build failed]
```