### PR TITLE
Use a new ConnectionError type for network errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -71,3 +71,16 @@ func badStreamPanic(err error) {
 func badStreamPanicf(format string, v ...interface{}) {
 	panic(streamErrorf(format, v...))
 }
+
+type ConnectionError struct {
+	Message string
+	Err     error
+}
+
+func (c ConnectionError) Error() string {
+	return fmt.Sprintf("%s: %v", c.Message, c.Err)
+}
+
+func connectionError(message string, err error) ConnectionError {
+	return ConnectionError{Message: message, Err: err}
+}

--- a/mssql.go
+++ b/mssql.go
@@ -227,7 +227,7 @@ func (c *Conn) sendCommitRequest() error {
 			c.sess.log.Printf("Failed to send CommitXact with %v", err)
 		}
 		c.connectionGood = false
-		return fmt.Errorf("Faild to send CommitXact: %v", err)
+		return connectionError("Failed to send CommitXact", err)
 	}
 	return nil
 }
@@ -254,7 +254,7 @@ func (c *Conn) sendRollbackRequest() error {
 			c.sess.log.Printf("Failed to send RollbackXact with %v", err)
 		}
 		c.connectionGood = false
-		return fmt.Errorf("Failed to send RollbackXact: %v", err)
+		return connectionError("Failed to send RollbackXact", err)
 	}
 	return nil
 }
@@ -291,7 +291,7 @@ func (c *Conn) sendBeginRequest(ctx context.Context, tdsIsolation isoLevel) erro
 			c.sess.log.Printf("Failed to send BeginXact with %v", err)
 		}
 		c.connectionGood = false
-		return fmt.Errorf("Failed to send BeginXact: %v", err)
+		return connectionError("Failed to send BeginXant", err)
 	}
 	return nil
 }
@@ -438,7 +438,7 @@ func (s *Stmt) sendQuery(args []namedValue) (err error) {
 				conn.sess.log.Printf("Failed to send SqlBatch with %v", err)
 			}
 			conn.connectionGood = false
-			return fmt.Errorf("failed to send SQL Batch: %v", err)
+			return connectionError("Failed to send SQL Batch", err)
 		}
 	} else {
 		proc := sp_ExecuteSql
@@ -463,7 +463,7 @@ func (s *Stmt) sendQuery(args []namedValue) (err error) {
 				conn.sess.log.Printf("Failed to send Rpc with %v", err)
 			}
 			conn.connectionGood = false
-			return fmt.Errorf("Failed to send RPC: %v", err)
+			return connectionError("Failed to send RPC", err)
 		}
 	}
 	return


### PR DESCRIPTION
It has been useful for us to be able to test if returned errors are
variations of "network connection gone", so we have added this change to
our own code. Submitting it to upstream in case it is useful.