### PR TITLE
update error message in bulkcopy_sql.go

### DIFF
--- a/bulkcopy_sql.go
+++ b/bulkcopy_sql.go
@@ -66,7 +66,7 @@ func (ci *copyin) Query(v []driver.Value) (r driver.Rows, err error) {
 
 func (ci *copyin) Exec(v []driver.Value) (r driver.Result, err error) {
 	if ci.closed {
-		return nil, errors.New("errCopyInClosed")
+		return nil, errors.New("copyin query is closed")
 	}
 
 	if len(v) == 0 {


### PR DESCRIPTION
Hello,

Ran into this error message the other day: `errCopyInClosed` and was confused by the message. It was unclear at first glance what the message meant base on the style of the message. It is unlike other messages that follow an all lowercase sentence style.

This led us to the source code to find out if `errCopyInClosed` was supposed to be an error variable with the real message as string and it was printing incorrectly.

My proposition is to make the error look like `copyin query is closed` to follow the style of existing errors like [this line](https://github.com/denisenkom/go-mssqldb/blob/8fac8b954edb5b2b4ade733422de37ced41823c8/mssql_go19.go#L75) and other lines like it.

Thanks,
Travis