### PR TITLE
Change TLS hostname when routed to another SQL server

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1360,6 +1360,7 @@ continue_login:
 	if sess.routedServer != "" {
 		toconn.Close()
 		p.host = sess.routedServer
+		p.hostInCertificate = sess.routedServer
 		p.port = uint64(sess.routedPort)
 		goto initiate_connection
 	}


### PR DESCRIPTION
Currently setting TrustServerCertificate=false does not work on Azure SQL, because of the redirects to another server with a different hostname and different certificate being served.

Here we update the hostname used for TLS before setting up the redirected connection.

If this causes problems for anyone, one would need to perhaps introduce another connection parameter (hostNameInCertificateAfterRedirect or similar); but this works well against Azure SQL according to our tests.