### PR TITLE
mssql.TVP refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ are supported:
  * "cloud.google.com/go/civil".Date -> date
  * "cloud.google.com/go/civil".DateTime -> datetime2
  * "cloud.google.com/go/civil".Time -> time
- * mssql.TVPType -> Table Value Parameter (TDS version dependent)
+ * mssql.TVP -> Table Value Parameter (TDS version dependent)
 
 ## Important Notes
 

--- a/examples/tvp/tvp.go
+++ b/examples/tvp/tvp.go
@@ -120,9 +120,9 @@ func main() {
 		},
 	}
 
-	tvpType := mssql.TVPType{
-		TVPTypeName: "TestTVPSchema.exampleTVP",
-		TVPValue:    exampleData,
+	tvpType := mssql.TVP{
+		TypeName: "TestTVPSchema.exampleTVP",
+		Value:    exampleData,
 	}
 
 	rows, err := conn.Query(execTvp,

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -112,7 +112,7 @@ func (c *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 		*v = 0 // By default the return value should be zero.
 		c.returnStatus = v
 		return driver.ErrRemoveArgument
-	case TVPType:
+	case TVP:
 		return nil
 	default:
 		var err error
@@ -162,12 +162,12 @@ func (s *Stmt) makeParamExtra(val driver.Value) (res param, err error) {
 	case sql.Out:
 		res, err = s.makeParam(val.Dest)
 		res.Flags = fByRevValue
-	case TVPType:
+	case TVP:
 		err = val.check()
 		if err != nil {
 			return
 		}
-		schema, name, errGetName := getSchemeAndName(val.TVPTypeName)
+		schema, name, errGetName := getSchemeAndName(val.TypeName)
 		if errGetName != nil {
 			return
 		}

--- a/tvp_go19_db_test.go
+++ b/tvp_go19_db_test.go
@@ -275,13 +275,13 @@ func TestTVP(t *testing.T) {
 		},
 	}
 
-	tvpType := TVPType{
-		TVPTypeName: "tvptable",
-		TVPValue:    param1,
+	tvpType := TVP{
+		TypeName: "tvptable",
+		Value:    param1,
 	}
-	tvpTypeEmpty := TVPType{
-		TVPTypeName: "tvptable",
-		TVPValue:    []TvptableRow{},
+	tvpTypeEmpty := TVP{
+		TypeName: "tvptable",
+		Value:    []TvptableRow{},
 	}
 
 	rows, err := db.QueryContext(ctx,
@@ -519,13 +519,13 @@ func TestTVP_WithTag(t *testing.T) {
 		},
 	}
 
-	tvpType := TVPType{
-		TVPTypeName: "tvptable",
-		TVPValue:    param1,
+	tvpType := TVP{
+		TypeName: "tvptable",
+		Value:    param1,
 	}
-	tvpTypeEmpty := TVPType{
-		TVPTypeName: "tvptable",
-		TVPValue:    []TvptableRowWithSkipTag{},
+	tvpTypeEmpty := TVP{
+		TypeName: "tvptable",
+		Value:    []TvptableRowWithSkipTag{},
 	}
 
 	rows, err := db.QueryContext(ctx,
@@ -653,9 +653,9 @@ func TestTVPSchema(t *testing.T) {
 		},
 	}
 
-	tvpType := TVPType{
-		TVPTypeName: "exempleTVP",
-		TVPValue:    exempleData,
+	tvpType := TVP{
+		TypeName: "exempleTVP",
+		Value:    exempleData,
 	}
 
 	rows, err := conn.Query(execTvp,

--- a/tvp_go19_test.go
+++ b/tvp_go19_test.go
@@ -60,21 +60,21 @@ func TestTVPType_columnTypes(t *testing.T) {
 			},
 		},
 		{
-			name: "TVPValue has wrong field type",
+			name: "Value has wrong field type",
 			fields: fields{
 				TVPValue: []TestFieldError{TestFieldError{}},
 			},
 			wantErr: true,
 		},
 		{
-			name: "TVPValue has wrong type",
+			name: "Value has wrong type",
 			fields: fields{
 				TVPValue: []TestFieldsUnsupportedTypes{},
 			},
 			wantErr: true,
 		},
 		{
-			name: "TVPValue has wrong type",
+			name: "Value has wrong type",
 			fields: fields{
 				TVPValue: []structType{},
 			},
@@ -111,13 +111,13 @@ func TestTVPType_columnTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tvp := TVPType{
-				TVPTypeName: tt.fields.TVPName,
-				TVPValue:    tt.fields.TVPValue,
+			tvp := TVP{
+				TypeName: tt.fields.TVPName,
+				Value:    tt.fields.TVPValue,
 			}
 			_, _, err := tvp.columnTypes()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("TVPType.columnTypes() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("TVP.columnTypes() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
@@ -138,11 +138,11 @@ func TestTVPType_check(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "TVPTypeName is nil",
+			name:    "TypeName is nil",
 			wantErr: true,
 		},
 		{
-			name: "TVPValue is nil",
+			name: "Value is nil",
 			fields: fields{
 				TVPName:  "Test",
 				TVPValue: nil,
@@ -150,14 +150,14 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "TVPValue is nil",
+			name: "Value is nil",
 			fields: fields{
 				TVPName: "Test",
 			},
 			wantErr: true,
 		},
 		{
-			name: "TVPValue isn't slice",
+			name: "Value isn't slice",
 			fields: fields{
 				TVPName:  "Test",
 				TVPValue: "",
@@ -165,7 +165,7 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "TVPValue isn't slice",
+			name: "Value isn't slice",
 			fields: fields{
 				TVPName:  "Test",
 				TVPValue: 12345,
@@ -173,7 +173,7 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "TVPValue isn't slice",
+			name: "Value isn't slice",
 			fields: fields{
 				TVPName:  "Test",
 				TVPValue: nullSlice,
@@ -181,7 +181,7 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "TVPValue isn't right",
+			name: "Value isn't right",
 			fields: fields{
 				TVPName:  "Test",
 				TVPValue: []*fields{},
@@ -189,7 +189,7 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "TVPValue is right",
+			name: "Value is right",
 			fields: fields{
 				TVPName:  "Test",
 				TVPValue: []fields{},
@@ -197,7 +197,7 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "TVPValue is right",
+			name: "Value is right",
 			fields: fields{
 				TVPName:  "Test",
 				TVPValue: []fields{},
@@ -205,7 +205,7 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "TVPValue is right",
+			name: "Value is right",
 			fields: fields{
 				TVPName:  "[Test]",
 				TVPValue: []fields{},
@@ -213,7 +213,7 @@ func TestTVPType_check(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "TVPValue is right",
+			name: "Value is right",
 			fields: fields{
 				TVPName:  "[123].[Test]",
 				TVPValue: []fields{},
@@ -255,12 +255,12 @@ func TestTVPType_check(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tvp := TVPType{
-				TVPTypeName: tt.fields.TVPName,
-				TVPValue:    tt.fields.TVPValue,
+			tvp := TVP{
+				TypeName: tt.fields.TVPName,
+				Value:    tt.fields.TVPValue,
 			}
 			if err := tvp.check(); (err != nil) != tt.wantErr {
-				t.Errorf("TVPType.check() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("TVP.check() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -279,7 +279,7 @@ func TestTVPType_encode(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "TVPValue gets error unsupported type",
+			name: "Value gets error unsupported type",
 			fields: fields{
 				TVPTypeName: "Test",
 				TVPValue:    []TestFieldError{},
@@ -289,9 +289,9 @@ func TestTVPType_encode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tvp := TVPType{
-				TVPTypeName: tt.fields.TVPTypeName,
-				TVPValue:    tt.fields.TVPValue,
+			tvp := TVP{
+				TypeName: tt.fields.TVPTypeName,
+				Value:    tt.fields.TVPValue,
 			}
 			schema, name, err := getSchemeAndName(tt.fields.TVPTypeName)
 			if err != nil {
@@ -299,7 +299,7 @@ func TestTVPType_encode(t *testing.T) {
 			}
 			_, err = tvp.encode(schema, name)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("TVPType.encode() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("TVP.encode() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -309,9 +309,9 @@ func BenchmarkTVPType_check(b *testing.B) {
 	type val struct {
 		Value string
 	}
-	tvp := TVPType{
-		TVPTypeName: "Test",
-		TVPValue:    []val{},
+	tvp := TVP{
+		TypeName: "Test",
+		Value:    []val{},
 	}
 	for i := 0; i < b.N; i++ {
 		err := tvp.check()
@@ -354,9 +354,9 @@ func BenchmarkColumnTypes(b *testing.B) {
 		boolsNull *bool
 	}
 	wal := make([]str, 100)
-	tvp := TVPType{
-		TVPTypeName: "Test",
-		TVPValue:    wal,
+	tvp := TVP{
+		TypeName: "Test",
+		Value:    wal,
 	}
 	for i := 0; i < b.N; i++ {
 		_, _, err := tvp.columnTypes()

--- a/types.go
+++ b/types.go
@@ -73,14 +73,10 @@ const (
 const _PLP_NULL = 0xFFFFFFFFFFFFFFFF
 const _UNKNOWN_PLP_LEN = 0xFFFFFFFFFFFFFFFE
 const _PLP_TERMINATOR = 0x00000000
-const _TVP_NULL_TOKEN = 0xffff
 
 // TVP COLUMN FLAGS
-const _TVP_COLUMN_DEFAULT_FLAG = 0x200
 const _TVP_END_TOKEN = 0x00
 const _TVP_ROW_TOKEN = 0x01
-const _TVP_ORDER_UNIQUE_TOKEN = 0x10
-const _TVP_COLUMN_ORDERING_TOKEN = 0x11
 
 // TYPE_INFO rule
 // http://msdn.microsoft.com/en-us/library/dd358284.aspx


### PR DESCRIPTION
#458 refactoring
Renamed fields.
Removed unused fields.
```
type TVP struct {
	//TypeName mustn't be default value
	TypeName string
	//Value must be the slice, mustn't be nil
	Value interface{}
}
```