### PR TITLE
SSPI authentication problem with SQL Server 2016

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -351,7 +351,6 @@ func (d *Driver) connect(ctx context.Context, c *Connector, params connectParams
 		processQueryText: d.processQueryText,
 		connectionGood:   true,
 	}
-	conn.sess.log = d.log
 
 	return conn, nil
 }

--- a/tds.go
+++ b/tds.go
@@ -1318,42 +1318,43 @@ initiate_connection:
 	}
 
 	// processing login response
-	var sspi_msg []byte
-continue_login:
-	tokchan := make(chan tokenStruct, 5)
-	go processResponse(context.Background(), &sess, tokchan, nil)
 	success := false
-	for tok := range tokchan {
-		switch token := tok.(type) {
-		case sspiMsg:
-			sspi_msg, err = auth.NextBytes(token)
-			if err != nil {
-				return nil, err
-			}
-		case loginAckStruct:
-			success = true
-			sess.loginAck = token
-		case error:
-			return nil, fmt.Errorf("Login error: %s", token.Error())
-		case doneStruct:
-			if token.isError() {
-				return nil, fmt.Errorf("Login error: %s", token.getError())
+	for {
+		tokchan := make(chan tokenStruct, 5)
+		go processResponse(context.Background(), &sess, tokchan, nil)
+		for tok := range tokchan {
+			switch token := tok.(type) {
+			case sspiMsg:
+				sspi_msg, err := auth.NextBytes(token)
+				if err != nil {
+					return nil, err
+				}
+				if sspi_msg != nil && len(sspi_msg) > 0 {
+					outbuf.BeginPacket(packSSPIMessage, false)
+					_, err = outbuf.Write(sspi_msg)
+					if err != nil {
+						return nil, err
+					}
+					err = outbuf.FinishPacket()
+					if err != nil {
+						return nil, err
+					}
+					sspi_msg = nil
+				}
+			case loginAckStruct:
+				success = true
+				sess.loginAck = token
+			case error:
+				return nil, fmt.Errorf("Login error: %s", token.Error())
+			case doneStruct:
+				if token.isError() {
+					return nil, fmt.Errorf("Login error: %s", token.getError())
+				}
+				goto loginEnd
 			}
 		}
 	}
-	if sspi_msg != nil {
-		outbuf.BeginPacket(packSSPIMessage, false)
-		_, err = outbuf.Write(sspi_msg)
-		if err != nil {
-			return nil, err
-		}
-		err = outbuf.FinishPacket()
-		if err != nil {
-			return nil, err
-		}
-		sspi_msg = nil
-		goto continue_login
-	}
+loginEnd:
 	if !success {
 		return nil, fmt.Errorf("Login failed")
 	}


### PR DESCRIPTION
This fixes error in SSPI authetication handshake which caused that user was immediately logged out after login in. This later resulted in error during sending SQL batch:
`failed to send SQL Batch: write tcp 127.0.0.1:5542->127.0.0.1:1433: wsasend: An existing connection was forcibly closed by the remote host.`

Reported in #475, and also mentioned in #450.

Fix was done by:
- Skipping sending empty sspi messages
- Continue login message loop even we don't have a sspi message  

Fix was verified for both SQL Authentication and Windows Authentication with SQL Server 2016 Standard.