### PR TITLE
Update hostInCertificate when server respond with routed server

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1051,11 +1051,11 @@ func parseConnectParams(dsn string) (connectParams, error) {
 	}
 	p.certificate = params["certificate"]
 	p.hostInCertificate, ok = params["hostnameincertificate"]
-	if !ok {
+	if ok {
+		p.hostInCertificateProvided = true
+	} else {
 		p.hostInCertificate = p.host
 		p.hostInCertificateProvided = false
-	} else {
-		p.hostInCertificateProvided = true
 	}
 
 	serverSPN, ok := params["serverspn"]

--- a/tds.go
+++ b/tds.go
@@ -655,28 +655,29 @@ func sendAttention(buf *tdsBuffer) error {
 }
 
 type connectParams struct {
-	logFlags               uint64
-	port                   uint64
-	host                   string
-	instance               string
-	database               string
-	user                   string
-	password               string
-	dial_timeout           time.Duration
-	conn_timeout           time.Duration
-	keepAlive              time.Duration
-	encrypt                bool
-	disableEncryption      bool
-	trustServerCertificate bool
-	certificate            string
-	hostInCertificate      string
-	serverSPN              string
-	workstation            string
-	appname                string
-	typeFlags              uint8
-	failOverPartner        string
-	failOverPort           uint64
-	packetSize             uint16
+	logFlags                  uint64
+	port                      uint64
+	host                      string
+	instance                  string
+	database                  string
+	user                      string
+	password                  string
+	dial_timeout              time.Duration
+	conn_timeout              time.Duration
+	keepAlive                 time.Duration
+	encrypt                   bool
+	disableEncryption         bool
+	trustServerCertificate    bool
+	certificate               string
+	hostInCertificate         string
+	hostInCertificateProvided bool
+	serverSPN                 string
+	workstation               string
+	appname                   string
+	typeFlags                 uint8
+	failOverPartner           string
+	failOverPort              uint64
+	packetSize                uint16
 }
 
 func splitConnectionString(dsn string) (res map[string]string) {
@@ -1052,6 +1053,9 @@ func parseConnectParams(dsn string) (connectParams, error) {
 	p.hostInCertificate, ok = params["hostnameincertificate"]
 	if !ok {
 		p.hostInCertificate = p.host
+		p.hostInCertificateProvided = false
+	} else {
+		p.hostInCertificateProvided = true
 	}
 
 	serverSPN, ok := params["serverspn"]
@@ -1361,6 +1365,9 @@ continue_login:
 		toconn.Close()
 		p.host = sess.routedServer
 		p.port = uint64(sess.routedPort)
+		if !p.hostInCertificateProvided {
+			p.hostInCertificate = sess.routedServer
+		}
 		goto initiate_connection
 	}
 	return &sess, nil


### PR DESCRIPTION
Upon connection, when the server respond with a rerouted server, the driver change the `p.host` to the `routedServer` and the `p.port` to the `routedPort`. However, the `hostInCertificate` is not updated.

When encrypt is true and trustservercertificate is false, the driver tries to validate the server certificate. This fails if `hostInCertificate` was not updated to the `routedServer` since there is a mismatch between the server certificate being validated (i.e., the certificate in the rerouted server) and the host name the driver provides to be used during certificate validation (i.e., the original server the client wants to connect to).

This change makes sure the `hostInCertificate` is updated when the server respond with a rerouted server, but ONLY IF the client did not provide the hostNameInCertificate in their connection string.