### PR TITLE
internal/querytext: new package that extracts the parameter parser

### DIFF
--- a/internal/querytext/parser.go
+++ b/internal/querytext/parser.go
@@ -1,4 +1,8 @@
-package mssql
+// Package querytext is the old query parser and parameter substitute process.
+// Do not use on new code.
+//
+// This package is not subject to any API compatibility guarantee.
+package querytext
 
 import (
 	"bytes"
@@ -40,7 +44,11 @@ func (p *parser) write(ch rune) {
 
 type stateFunc func(*parser) stateFunc
 
-func parseParams(query string) (string, int) {
+// ParseParams rewrites the query from using "?" placeholders
+// to using "@pN" parameter names that SQL Server will accept.
+//
+// This function and package is not subject to any API compatibility guarantee.
+func ParseParams(query string) (string, int) {
 	p := &parser{
 		r:           bytes.NewReader([]byte(query)),
 		namedParams: map[string]bool{},

--- a/internal/querytext/parser_test.go
+++ b/internal/querytext/parser_test.go
@@ -1,4 +1,4 @@
-package mssql
+package querytext
 
 import (
 	"testing"
@@ -49,7 +49,7 @@ func TestParseParams(t *testing.T) {
 	}
 
 	for _, v := range values {
-		d, n := parseParams(v.s)
+		d, n := ParseParams(v.s)
 		if d != v.d {
 			t.Errorf("Parse params don't match for %s, got %s but expected %s", v.s, d, v.d)
 		}

--- a/mssql.go
+++ b/mssql.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/denisenkom/go-mssqldb/internal/querytext"
 )
 
 // ReturnStatus may be used to return the return value from a proc.
@@ -385,7 +387,7 @@ func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 func (c *Conn) prepareContext(ctx context.Context, query string) (*Stmt, error) {
 	paramCount := -1
 	if c.processQueryText {
-		query, paramCount = parseParams(query)
+		query, paramCount = querytext.ParseParams(query)
 	}
 	return &Stmt{c, query, paramCount, nil}, nil
 }


### PR DESCRIPTION
Prior to v1, we should remove the query pre-parser from the main driver.
Also prior to v1, we can create a new Connector that does the processing.