### PR TITLE
Varchar sizefix

### DIFF
--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -29,7 +29,11 @@ func TestBulkcopy(t *testing.T) {
 	testValues := []testValue{
 
 		{"test_nvarchar", "ab©ĎéⒻghïjklmnopqЯ☀tuvwxyz"},
+		{"test_nvarchar_4000", strings.Repeat("Ⓕ", 4000)}, // edge case
+		{"test_nvarchar_max", strings.Repeat("Ⓕ", 4001)},
 		{"test_varchar", "abcdefg"},
+		{"test_varchar_8000", strings.Repeat("a", 8000)}, // edge case
+		{"test_varchar_max", strings.Repeat("a", 8001)},
 		{"test_char", "abcdefg   "},
 		{"test_nchar", "abcdefg   "},
 		{"test_text", "abcdefg"},
@@ -183,7 +187,11 @@ func setupTable(ctx context.Context, t *testing.T, conn *sql.Conn, tableName str
 	tablesql := `CREATE TABLE ` + tableName + ` (
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[test_nvarchar] [nvarchar](50) NULL,
+	[test_nvarchar_4000] [nvarchar](4000) NULL,
+	[test_nvarchar_max] [nvarchar](max) NULL,
 	[test_varchar] [varchar](50) NULL,
+	[test_varchar_8000] [varchar](8000) NULL,
+	[test_varchar_max] [varchar](max) NULL,
 	[test_char] [char](10) NULL,
 	[test_nchar] [nchar](10) NULL,
 	[test_text] [text] NULL,

--- a/types.go
+++ b/types.go
@@ -1186,7 +1186,7 @@ func makeDecl(ti typeInfo) string {
 	case typeBigChar, typeChar:
 		return fmt.Sprintf("char(%d)", ti.Size)
 	case typeBigVarChar, typeVarChar:
-		if ti.Size > 4000 || ti.Size == 0 {
+		if ti.Size > 8000 || ti.Size == 0 {
 			return fmt.Sprintf("varchar(max)")
 		} else {
 			return fmt.Sprintf("varchar(%d)", ti.Size)

--- a/types.go
+++ b/types.go
@@ -1186,11 +1186,7 @@ func makeDecl(ti typeInfo) string {
 	case typeBigChar, typeChar:
 		return fmt.Sprintf("char(%d)", ti.Size)
 	case typeBigVarChar, typeVarChar:
-<<<<<<< HEAD
-		if ti.Size == 0xffff || ti.Size == 0 {
-=======
 		if ti.Size > 8000 || ti.Size == 0 {
->>>>>>> 96234f6... revert changes to types.go change varchar(max) size
 			return fmt.Sprintf("varchar(max)")
 		} else {
 			return fmt.Sprintf("varchar(%d)", ti.Size)

--- a/types.go
+++ b/types.go
@@ -1176,7 +1176,7 @@ func makeDecl(ti typeInfo) string {
 			panic("invalid size of MONEYNTYPE")
 		}
 	case typeBigVarBin:
-		if ti.Size == 0xffff || ti.Size == 0 {
+		if ti.Size > 8000 || ti.Size == 0 {
 			return "varbinary(max)"
 		} else {
 			return fmt.Sprintf("varbinary(%d)", ti.Size)
@@ -1192,7 +1192,7 @@ func makeDecl(ti typeInfo) string {
 			return fmt.Sprintf("varchar(%d)", ti.Size)
 		}
 	case typeNVarChar:
-		if ti.Size == 0xffff || ti.Size == 0 {
+		if ti.Size > 8000 || ti.Size == 0 {
 			return "nvarchar(max)"
 		} else {
 			return fmt.Sprintf("nvarchar(%d)", ti.Size/2)

--- a/types.go
+++ b/types.go
@@ -1176,7 +1176,7 @@ func makeDecl(ti typeInfo) string {
 			panic("invalid size of MONEYNTYPE")
 		}
 	case typeBigVarBin:
-		if ti.Size > 8000 || ti.Size == 0 {
+		if ti.Size == 0xffff || ti.Size == 0 {
 			return "varbinary(max)"
 		} else {
 			return fmt.Sprintf("varbinary(%d)", ti.Size)
@@ -1186,13 +1186,13 @@ func makeDecl(ti typeInfo) string {
 	case typeBigChar, typeChar:
 		return fmt.Sprintf("char(%d)", ti.Size)
 	case typeBigVarChar, typeVarChar:
-		if ti.Size > 8000 || ti.Size == 0 {
+		if ti.Size == 0xffff || ti.Size == 0 {
 			return fmt.Sprintf("varchar(max)")
 		} else {
 			return fmt.Sprintf("varchar(%d)", ti.Size)
 		}
 	case typeNVarChar:
-		if ti.Size > 8000 || ti.Size == 0 {
+		if ti.Size == 0xffff || ti.Size == 0 {
 			return "nvarchar(max)"
 		} else {
 			return fmt.Sprintf("nvarchar(%d)", ti.Size/2)

--- a/types.go
+++ b/types.go
@@ -1186,7 +1186,11 @@ func makeDecl(ti typeInfo) string {
 	case typeBigChar, typeChar:
 		return fmt.Sprintf("char(%d)", ti.Size)
 	case typeBigVarChar, typeVarChar:
+<<<<<<< HEAD
 		if ti.Size == 0xffff || ti.Size == 0 {
+=======
+		if ti.Size > 8000 || ti.Size == 0 {
+>>>>>>> 96234f6... revert changes to types.go change varchar(max) size
 			return fmt.Sprintf("varchar(max)")
 		} else {
 			return fmt.Sprintf("varchar(%d)", ti.Size)

--- a/types_test.go
+++ b/types_test.go
@@ -116,6 +116,33 @@ func TestMakeGoLangTypePrecisionScale(t *testing.T) {
 	}
 }
 
+func TestMakeDecl(t *testing.T) {
+	defer handlePanic(t)
+
+	tests := []struct {
+		typeName string
+		Size     int
+		typeID   uint8
+	}{
+		{"varchar(max)", 0xffff, typeVarChar},
+		{"varchar(8000)", 8000, typeVarChar},
+		{"varchar(4001)", 4001, typeVarChar},
+		{"nvarchar(max)", 0xffff, typeNVarChar},
+		{"nvarchar(4000)", 8000, typeNVarChar},
+		{"nvarchar(2001)", 4002, typeNVarChar},
+		{"varbinary(max)", 0xffff, typeBigVarBin},
+		{"varbinary(8000)", 8000, typeBigVarBin},
+		{"varbinary(4001)", 4001, typeBigVarBin},
+	}
+
+	for _, tt := range tests {
+		s := makeDecl(typeInfo{TypeId: tt.typeID, Size: tt.Size})
+		if s != tt.typeName {
+			t.Errorf("invalid type translation for %s", tt.typeName)
+		}
+	}
+}
+
 func handlePanic(t *testing.T) {
 	if r := recover(); r != nil {
 		t.Errorf("recovered panic")


### PR DESCRIPTION
Fixed the incorrect `varchar(max)` size in [types.go](https://github.com/denisenkom/go-mssqldb/blob/master/types.go#L1189) and made the size checks for `nvarchar` and `varbinary` in line with [`makeGoLangTypeLength()`](https://github.com/denisenkom/go-mssqldb/blob/master/types.go#L1437). In addition I added a unit test to make sure these types return the correct type corresponding to their size. I also modified the bulk insert test to check that these cases are inserted without truncation or error.

Fixes #497 