### PR TITLE
Use the dial timeout variable

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 	"unicode/utf16"
 	"unicode/utf8"
 )
@@ -48,15 +47,13 @@ func parseInstances(msg []byte) map[string]map[string]string {
 }
 
 func getInstances(ctx context.Context, d Dialer, address string) (map[string]map[string]string, error) {
-	maxTime := 5 * time.Second
-	ctx, cancel := context.WithTimeout(ctx, maxTime)
-	defer cancel()
 	conn, err := d.DialContext(ctx, "udp", address+":1434")
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
-	conn.SetDeadline(time.Now().Add(maxTime))
+	deadline, _ := ctx.Deadline()
+	conn.SetDeadline(deadline)
 	_, err = conn.Write([]byte{3})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The `dial_timeout` variable does not seem to be used by the driver correctly. In `connect` of `tds.go`, `p.dial_timeout` is used to set the context timeout (https://github.com/denisenkom/go-mssqldb/blob/master/tds.go#L723). In `getInstances` of `tds.go`, the timeout value of the same context is overwritten by a hard coded value of 5 seconds (https://github.com/denisenkom/go-mssqldb/blob/master/tds.go#L52). The deadline of the `conn` object should also be set to the remainder of the context instead of the hard coded 5 seconds value.

Fix for #522 .