### PR TITLE
Enable consumption into secretless-broker

### DIFF
--- a/buf_test.go
+++ b/buf_test.go
@@ -29,15 +29,15 @@ func (failBuffer) Close() error {
 	return nil
 }
 
-func makeBuf(bufSize uint16, testData []byte) *tdsBuffer {
+func makeBuf(bufSize uint16, testData []byte) *TdsBuffer {
 	buffer := closableBuffer{bytes.NewBuffer(testData)}
-	return newTdsBuffer(bufSize, &buffer)
+	return NewTdsBuffer(bufSize, &buffer)
 }
 
 func TestStreamShorterThanHeader(t *testing.T) {
 	//buffer := closableBuffer{*bytes.NewBuffer([]byte{0xFF, 0xFF})}
 	//buffer := closableBuffer{*bytes.NewBuffer([]byte{0x6F, 0x96, 0x19, 0xFF, 0x8B, 0x86, 0xD0, 0x11, 0xB4, 0x2D, 0x00, 0xC0, 0x4F, 0xC9, 0x64, 0xFF})}
-	//tdsBuffer := newTdsBuffer(100, &buffer)
+	//TdsBuffer := NewTdsBuffer(100, &buffer)
 	buffer := makeBuf(100, []byte{0xFF, 0xFF})
 	_, err := buffer.BeginRead()
 	if err == nil {
@@ -187,7 +187,7 @@ func TestReadFailsOnSecondPacket(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	memBuf := bytes.NewBuffer([]byte{})
-	buf := newTdsBuffer(11, closableBuffer{memBuf})
+	buf := NewTdsBuffer(11, closableBuffer{memBuf})
 	buf.BeginPacket(1, false)
 	err := buf.WriteByte(2)
 	if err != nil {
@@ -233,7 +233,7 @@ func TestWrite(t *testing.T) {
 
 func TestWriteErrors(t *testing.T) {
 	// write should fail if underlying transport fails
-	buf := newTdsBuffer(uint16(headerSize)+1, failBuffer{})
+	buf := NewTdsBuffer(uint16(headerSize)+1, failBuffer{})
 	buf.BeginPacket(1, false)
 	wrote, err := buf.Write([]byte{0, 0})
 	// may change from error to panic in future
@@ -245,7 +245,7 @@ func TestWriteErrors(t *testing.T) {
 	}
 
 	// writebyte should fail if underlying transport fails
-	buf = newTdsBuffer(uint16(headerSize)+1, failBuffer{})
+	buf = NewTdsBuffer(uint16(headerSize)+1, failBuffer{})
 	buf.BeginPacket(1, false)
 	// first write should not fail because if fits in the buffer
 	err = buf.WriteByte(0)
@@ -261,7 +261,7 @@ func TestWriteErrors(t *testing.T) {
 
 func TestWrite_BufferBounds(t *testing.T) {
 	memBuf := bytes.NewBuffer([]byte{})
-	buf := newTdsBuffer(11, closableBuffer{memBuf})
+	buf := NewTdsBuffer(11, closableBuffer{memBuf})
 
 	buf.BeginPacket(1, false)
 	// write bytes enough to complete a package

--- a/mssql.go
+++ b/mssql.go
@@ -152,6 +152,11 @@ type Conn struct {
 	returnStatus *ReturnStatus
 }
 
+// NetConn exposes the underlying transport to the backend
+func (c *Conn) NetConn() net.Conn {
+	return c.sess.buf.transport.(net.Conn)
+}
+
 func (c *Conn) setReturnStatus(s ReturnStatus) {
 	if c.returnStatus == nil {
 		return

--- a/net.go
+++ b/net.go
@@ -7,8 +7,8 @@ import (
 )
 
 type timeoutConn struct {
-	c             net.Conn
-	timeout       time.Duration
+	c       net.Conn
+	timeout time.Duration
 }
 
 func newTimeoutConn(conn net.Conn, timeout time.Duration) *timeoutConn {
@@ -65,7 +65,7 @@ func (c timeoutConn) SetWriteDeadline(t time.Time) error {
 // this connection is used during TLS Handshake
 // TDS protocol requires TLS handshake messages to be sent inside TDS packets
 type tlsHandshakeConn struct {
-	buf *tdsBuffer
+	buf           *TdsBuffer
 	packetPending bool
 	continueRead  bool
 }

--- a/rpc.go
+++ b/rpc.go
@@ -46,7 +46,7 @@ var (
 )
 
 // http://msdn.microsoft.com/en-us/library/dd357576.aspx
-func sendRpc(buf *tdsBuffer, headers []headerStruct, proc procId, flags uint16, params []param, resetSession bool) (err error) {
+func sendRpc(buf *TdsBuffer, headers []headerStruct, proc procId, flags uint16, params []param, resetSession bool) (err error) {
 	buf.BeginPacket(packRPCRequest, resetSession)
 	writeAllHeaders(buf, headers)
 	if len(proc.name) == 0 {

--- a/tds_test.go
+++ b/tds_test.go
@@ -22,7 +22,7 @@ func (t *MockTransport) Close() error {
 
 func TestSendLogin(t *testing.T) {
 	memBuf := new(MockTransport)
-	buf := newTdsBuffer(1024, memBuf)
+	buf := NewTdsBuffer(1024, memBuf)
 	login := login{
 		TDSVersion:     verTDS73,
 		PacketSize:     0x1000,
@@ -175,8 +175,6 @@ func (l testLogger) Printf(format string, v ...interface{}) {
 func (l testLogger) Println(v ...interface{}) {
 	l.t.Log(v...)
 }
-
-
 
 func TestConnect(t *testing.T) {
 	checkConnStr(t)
@@ -413,7 +411,7 @@ func TestSSPIAuth(t *testing.T) {
 
 func TestUcs22Str(t *testing.T) {
 	// Test valid input
-	s, err := ucs22str([]byte{0x31, 0, 0x32, 0, 0x33, 0})  // 123 in UCS2 encoding
+	s, err := ucs22str([]byte{0x31, 0, 0x32, 0, 0x33, 0}) // 123 in UCS2 encoding
 	if err != nil {
 		t.Errorf("ucs22str should not fail for valid ucs2 byte sequence: %s", err)
 	}
@@ -429,7 +427,7 @@ func TestUcs22Str(t *testing.T) {
 }
 
 func TestReadUcs2(t *testing.T) {
-	buf := bytes.NewBuffer([]byte{0x31, 0, 0x32, 0, 0x33, 0})  // 123 in UCS2 encoding
+	buf := bytes.NewBuffer([]byte{0x31, 0, 0x32, 0, 0x33, 0}) // 123 in UCS2 encoding
 	s, err := readUcs2(buf, 3)
 	if err != nil {
 		t.Errorf("readUcs2 should not fail for valid ucs2 byte sequence: %s", err)
@@ -447,7 +445,7 @@ func TestReadUcs2(t *testing.T) {
 
 func TestReadUsVarChar(t *testing.T) {
 	// should succeed for valid buffer
-	buf := bytes.NewBuffer([]byte{3, 0, 0x31, 0, 0x32, 0, 0x33, 0})  // 123 in UCS2 encoding with length prefix 3 uint16
+	buf := bytes.NewBuffer([]byte{3, 0, 0x31, 0, 0x32, 0, 0x33, 0}) // 123 in UCS2 encoding with length prefix 3 uint16
 	s, err := readUsVarChar(buf)
 	if err != nil {
 		t.Errorf("readUsVarChar should not fail for valid ucs2 byte sequence: %s", err)

--- a/token.go
+++ b/token.go
@@ -386,11 +386,11 @@ func processEnvChg(sess *tdsSession) {
 }
 
 // http://msdn.microsoft.com/en-us/library/dd358180.aspx
-func parseReturnStatus(r *tdsBuffer) ReturnStatus {
+func parseReturnStatus(r *TdsBuffer) ReturnStatus {
 	return ReturnStatus(r.int32())
 }
 
-func parseOrder(r *tdsBuffer) (res orderStruct) {
+func parseOrder(r *TdsBuffer) (res orderStruct) {
 	len := int(r.uint16())
 	res.ColIds = make([]uint16, len/2)
 	for i := 0; i < len/2; i++ {
@@ -400,7 +400,7 @@ func parseOrder(r *tdsBuffer) (res orderStruct) {
 }
 
 // https://msdn.microsoft.com/en-us/library/dd340421.aspx
-func parseDone(r *tdsBuffer) (res doneStruct) {
+func parseDone(r *TdsBuffer) (res doneStruct) {
 	res.Status = r.uint16()
 	res.CurCmd = r.uint16()
 	res.RowCount = r.uint64()
@@ -408,7 +408,7 @@ func parseDone(r *tdsBuffer) (res doneStruct) {
 }
 
 // https://msdn.microsoft.com/en-us/library/dd340553.aspx
-func parseDoneInProc(r *tdsBuffer) (res doneInProcStruct) {
+func parseDoneInProc(r *TdsBuffer) (res doneInProcStruct) {
 	res.Status = r.uint16()
 	res.CurCmd = r.uint16()
 	res.RowCount = r.uint64()
@@ -417,7 +417,7 @@ func parseDoneInProc(r *tdsBuffer) (res doneInProcStruct) {
 
 type sspiMsg []byte
 
-func parseSSPIMsg(r *tdsBuffer) sspiMsg {
+func parseSSPIMsg(r *TdsBuffer) sspiMsg {
 	size := r.uint16()
 	buf := make([]byte, size)
 	r.ReadFull(buf)
@@ -431,7 +431,7 @@ type loginAckStruct struct {
 	ProgVer    uint32
 }
 
-func parseLoginAck(r *tdsBuffer) loginAckStruct {
+func parseLoginAck(r *TdsBuffer) loginAckStruct {
 	size := r.uint16()
 	buf := make([]byte, size)
 	r.ReadFull(buf)
@@ -448,7 +448,7 @@ func parseLoginAck(r *tdsBuffer) loginAckStruct {
 }
 
 // http://msdn.microsoft.com/en-us/library/dd357363.aspx
-func parseColMetadata72(r *tdsBuffer) (columns []columnStruct) {
+func parseColMetadata72(r *TdsBuffer) (columns []columnStruct) {
 	count := r.uint16()
 	if count == 0xffff {
 		// no metadata is sent
@@ -468,14 +468,14 @@ func parseColMetadata72(r *tdsBuffer) (columns []columnStruct) {
 }
 
 // http://msdn.microsoft.com/en-us/library/dd357254.aspx
-func parseRow(r *tdsBuffer, columns []columnStruct, row []interface{}) {
+func parseRow(r *TdsBuffer, columns []columnStruct, row []interface{}) {
 	for i, column := range columns {
 		row[i] = column.ti.Reader(&column.ti, r)
 	}
 }
 
 // http://msdn.microsoft.com/en-us/library/dd304783.aspx
-func parseNbcRow(r *tdsBuffer, columns []columnStruct, row []interface{}) {
+func parseNbcRow(r *TdsBuffer, columns []columnStruct, row []interface{}) {
 	bitlen := (len(columns) + 7) / 8
 	pres := make([]byte, bitlen)
 	r.ReadFull(pres)
@@ -489,7 +489,7 @@ func parseNbcRow(r *tdsBuffer, columns []columnStruct, row []interface{}) {
 }
 
 // http://msdn.microsoft.com/en-us/library/dd304156.aspx
-func parseError72(r *tdsBuffer) (res Error) {
+func parseError72(r *TdsBuffer) (res Error) {
 	length := r.uint16()
 	_ = length // ignore length
 	res.Number = r.int32()
@@ -503,7 +503,7 @@ func parseError72(r *tdsBuffer) (res Error) {
 }
 
 // http://msdn.microsoft.com/en-us/library/dd304156.aspx
-func parseInfo(r *tdsBuffer) (res Error) {
+func parseInfo(r *TdsBuffer) (res Error) {
 	length := r.uint16()
 	_ = length // ignore length
 	res.Number = r.int32()
@@ -517,7 +517,7 @@ func parseInfo(r *tdsBuffer) (res Error) {
 }
 
 // https://msdn.microsoft.com/en-us/library/dd303881.aspx
-func parseReturnValue(r *tdsBuffer) (nv namedValue) {
+func parseReturnValue(r *TdsBuffer) (nv namedValue) {
 	/*
 		ParamOrdinal
 		ParamName

--- a/tran.go
+++ b/tran.go
@@ -28,7 +28,7 @@ const (
 	isolationSnapshot                = 5
 )
 
-func sendBeginXact(buf *tdsBuffer, headers []headerStruct, isolation isoLevel, name string, resetSession bool) (err error) {
+func sendBeginXact(buf *TdsBuffer, headers []headerStruct, isolation isoLevel, name string, resetSession bool) (err error) {
 	buf.BeginPacket(packTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmBeginXact
@@ -51,7 +51,7 @@ const (
 	fBeginXact = 1
 )
 
-func sendCommitXact(buf *tdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
+func sendCommitXact(buf *TdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
 	buf.BeginPacket(packTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmCommitXact
@@ -80,7 +80,7 @@ func sendCommitXact(buf *tdsBuffer, headers []headerStruct, name string, flags u
 	return buf.FinishPacket()
 }
 
-func sendRollbackXact(buf *tdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
+func sendRollbackXact(buf *TdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
 	buf.BeginPacket(packTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmRollbackXact

--- a/types.go
+++ b/types.go
@@ -90,7 +90,7 @@ type typeInfo struct {
 	Collation cp.Collation
 	UdtInfo   udtInfo
 	XmlInfo   xmlInfo
-	Reader    func(ti *typeInfo, r *tdsBuffer) (res interface{})
+	Reader    func(ti *typeInfo, r *TdsBuffer) (res interface{})
 	Writer    func(w io.Writer, ti typeInfo, buf []byte) (err error)
 }
 
@@ -113,7 +113,7 @@ type xmlInfo struct {
 	XmlSchemaCollection string
 }
 
-func readTypeInfo(r *tdsBuffer) (res typeInfo) {
+func readTypeInfo(r *TdsBuffer) (res typeInfo) {
 	res.TypeId = r.byte()
 	switch res.TypeId {
 	case typeNull, typeInt1, typeBit, typeInt2, typeInt4, typeDateTim4,
@@ -309,7 +309,7 @@ func decodeDateTime(buf []byte) time.Time {
 		0, 0, secs, ns, time.UTC)
 }
 
-func readFixedType(ti *typeInfo, r *tdsBuffer) interface{} {
+func readFixedType(ti *typeInfo, r *TdsBuffer) interface{} {
 	r.ReadFull(ti.Buffer)
 	buf := ti.Buffer
 	switch ti.TypeId {
@@ -343,7 +343,7 @@ func readFixedType(ti *typeInfo, r *tdsBuffer) interface{} {
 	panic("shoulnd't get here")
 }
 
-func readByteLenType(ti *typeInfo, r *tdsBuffer) interface{} {
+func readByteLenType(ti *typeInfo, r *TdsBuffer) interface{} {
 	size := r.byte()
 	if size == 0 {
 		return nil
@@ -442,7 +442,7 @@ func writeByteLenType(w io.Writer, ti typeInfo, buf []byte) (err error) {
 	return
 }
 
-func readShortLenType(ti *typeInfo, r *tdsBuffer) interface{} {
+func readShortLenType(ti *typeInfo, r *TdsBuffer) interface{} {
 	size := r.uint16()
 	if size == 0xffff {
 		return nil
@@ -485,7 +485,7 @@ func writeShortLenType(w io.Writer, ti typeInfo, buf []byte) (err error) {
 	return
 }
 
-func readLongLenType(ti *typeInfo, r *tdsBuffer) interface{} {
+func readLongLenType(ti *typeInfo, r *TdsBuffer) interface{} {
 	// information about this format can be found here:
 	// http://msdn.microsoft.com/en-us/library/dd304783.aspx
 	// and here:
@@ -544,7 +544,7 @@ func writeLongLenType(w io.Writer, ti typeInfo, buf []byte) (err error) {
 	return
 }
 
-func readCollation(r *tdsBuffer) (res cp.Collation) {
+func readCollation(r *TdsBuffer) (res cp.Collation) {
 	res.LcidAndFlags = r.uint32()
 	res.SortId = r.byte()
 	return
@@ -560,7 +560,7 @@ func writeCollation(w io.Writer, col cp.Collation) (err error) {
 
 // reads variant value
 // http://msdn.microsoft.com/en-us/library/dd303302.aspx
-func readVariantType(ti *typeInfo, r *tdsBuffer) interface{} {
+func readVariantType(ti *typeInfo, r *TdsBuffer) interface{} {
 	size := r.int32()
 	if size == 0 {
 		return nil
@@ -652,7 +652,7 @@ func readVariantType(ti *typeInfo, r *tdsBuffer) interface{} {
 
 // partially length prefixed stream
 // http://msdn.microsoft.com/en-us/library/dd340469.aspx
-func readPLPType(ti *typeInfo, r *tdsBuffer) interface{} {
+func readPLPType(ti *typeInfo, r *TdsBuffer) interface{} {
 	size := r.uint64()
 	var buf *bytes.Buffer
 	switch size {
@@ -709,7 +709,7 @@ func writePLPType(w io.Writer, ti typeInfo, buf []byte) (err error) {
 	}
 }
 
-func readVarLen(ti *typeInfo, r *tdsBuffer) {
+func readVarLen(ti *typeInfo, r *TdsBuffer) {
 	switch ti.TypeId {
 	case typeDateN:
 		ti.Size = 3


### PR DESCRIPTION
We are adding a plugin to the `secretless-broker` project (https://github.com/cyberark/secretless-broker) and will be using your project to communicate with SQL Server. Secretless is written in `go` too and needs a bit more access to some of the internals of this project. In this PR we expose the constants & functions we need to use. Other than that, the logic stays the same.

The Secretless Broker lets your applications connect securely to services - without ever having to fetch or manage passwords or keys. It does so by acting as a connector between the application and the target, retrieving the credentials for authentication from a credentials provider. This way, it opens an authenticated stream between the application and the target, so the application doesn't need to manage credentials in its code. To do so with mssql, we need to get the underlying channel and and the credentials to the message. We needed access to some constants and structs to do so.

It would be great if these minor changes will be merged to the `go-mssqldb` project so we can consume it as a 3rd party to our project, rather than relying on our own fork.

