### PR TITLE
change query notification timeout from seconds to milliseconds

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -397,7 +397,7 @@ func (s *Stmt) Close() error {
 }
 
 func (s *Stmt) SetQueryNotification(id, options string, timeout time.Duration) {
-	to := uint32(timeout / time.Second)
+	to := uint32(timeout / time.Millisecond)
 	if to < 1 {
 		to = 1
 	}

--- a/mssql.go
+++ b/mssql.go
@@ -397,6 +397,9 @@ func (s *Stmt) Close() error {
 }
 
 func (s *Stmt) SetQueryNotification(id, options string, timeout time.Duration) {
+	// 2.2.5.3.1 Query Notifications Header
+	// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/e168d373-a7b7-41aa-b6ca-25985466a7e0
+	// Timeout in milliseconds in TDS protocol.
 	to := uint32(timeout / time.Millisecond)
 	if to < 1 {
 		to = 1


### PR DESCRIPTION
Addresses issue #526 . 

@jackwakefield, if you had a fix in the works let me know and I'll remove this PR.

Tested timeout using the query `select * from sys.dm_qn_subscriptions` and found that the timeout value was equal to the value set by the driver.