### PR TITLE
Allow server=hostname,port in ADO style dsn

### DIFF
--- a/conn_str.go
+++ b/conn_str.go
@@ -247,6 +247,15 @@ func splitConnectionString(dsn string) (res map[string]string) {
 			value = strings.TrimSpace(lst[1])
 		}
 		res[name] = value
+
+		// Allow "server=hostname,port" format
+		if name == "server" && strings.Contains(value, ",") {
+			values := strings.SplitN(value, ",", 2)
+			if len(values) == 2 {
+				res["server"] = strings.TrimSpace(values[0])
+				res["port"] = strings.TrimSpace(values[1])
+			}
+		}
 	}
 	return res
 }

--- a/conn_str_test.go
+++ b/conn_str_test.go
@@ -53,6 +53,7 @@ func TestValidConnectionString(t *testing.T) {
 		}},
 		{"server=.", func(p connectParams) bool { return p.host == "localhost" }},
 		{"server=(local)", func(p connectParams) bool { return p.host == "localhost" }},
+		{"server=somehost,1434", func(p connectParams) bool { return p.host == "somehost" && p.port == 1434 }},
 		{"ServerSPN=serverspn;Workstation ID=workstid", func(p connectParams) bool { return p.serverSPN == "serverspn" && p.workstation == "workstid" }},
 		{"failoverpartner=fopartner;failoverport=2000", func(p connectParams) bool { return p.failOverPartner == "fopartner" && p.failOverPort == 2000 }},
 		{"app name=appname;applicationintent=ReadOnly;database=testdb", func(p connectParams) bool { return p.appname == "appname" && (p.typeFlags&fReadOnlyIntent != 0) }},


### PR DESCRIPTION
ADO style connection string may contain `server=tcp:servername, portnumber` format.

<img width="793" alt="Screen Shot 2019-11-22 at 10 03 20" src="https://user-images.githubusercontent.com/1718007/69389438-5cc05300-0d0f-11ea-8e90-48ae8962c1f2.png">

[https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring?view=netframework-4.8](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring?view=netframework-4.8)

However, go-mssqldb does not handle this format properly. This PR allows `server=tcp:servername, portnumber` format in ADO style dsn.