### PR TITLE
make sure to call cancel func

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -613,11 +613,13 @@ loop:
 			break loop
 		case doneStruct:
 			if token.isError() {
+				cancel()
 				return nil, s.c.checkBadConn(token.getError())
 			}
 		case ReturnStatus:
 			s.c.setReturnStatus(token)
 		case error:
+			cancel()
 			return nil, s.c.checkBadConn(token)
 		}
 	}


### PR DESCRIPTION
Currently, `go vet` reports:
```
❯ go vet 2>&1 | grep mssql.go
./mssql.go:596:2: the cancel function is not used on all paths (possible context leak)
./mssql.go:616:5: this return statement may be reached without using the cancel var defined on line 596
```

This PR fixes these.