### PR TITLE
bulkcopy: correct string encoding insertion

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -395,9 +395,13 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 		switch val := val.(type) {
 		case string:
 			vr := []rune(val)
-			vb := make([]byte, len(vr))
-			for i := range vr {
-				vb[i] = byte(vr[i])
+			vb := make([]byte, 0)
+			for _, v := range vr {
+				if v <= 255 {
+					vb = append(vb, byte(v))
+				} else {
+					vb = append(vb, []byte(string(v))...)
+				}
 			}
 			res.buffer = vb
 		case []byte:

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -394,7 +394,12 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 	case typeVarChar, typeBigVarChar, typeText, typeChar, typeBigChar:
 		switch val := val.(type) {
 		case string:
-			res.buffer = []byte(val)
+			vr := []rune(val)
+			vb := make([]byte, len(vr))
+			for i := range vr {
+				vb[i] = byte(vr[i])
+			}
+			res.buffer = vb
 		case []byte:
 			res.buffer = val
 		default:

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -394,16 +394,7 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 	case typeVarChar, typeBigVarChar, typeText, typeChar, typeBigChar:
 		switch val := val.(type) {
 		case string:
-			vr := []rune(val)
-			vb := make([]byte, 0)
-			for _, v := range vr {
-				if v <= 255 {
-					vb = append(vb, byte(v))
-				} else {
-					vb = append(vb, []byte(string(v))...)
-				}
-			}
-			res.buffer = vb
+			res.buffer = str2ucs2(val)
 		case []byte:
 			res.buffer = val
 		default:

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -394,7 +394,16 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 	case typeVarChar, typeBigVarChar, typeText, typeChar, typeBigChar:
 		switch val := val.(type) {
 		case string:
-			res.buffer = str2ucs2(val)
+			vr := []rune(val)
+			vb := make([]byte, 0)
+			for _, v := range vr {
+				if v <= 255 {
+					vb = append(vb, byte(v))
+				} else {
+					vb = append(vb, []byte(string(v))...)
+				}
+			}
+			res.buffer = vb
 		case []byte:
 			res.buffer = val
 		default:


### PR DESCRIPTION
Insert to typeVarChar, typeBigVarChar, typeText, typeChar, typeBigChar requires to convert string->[]rune->[]byte

This correct insertion of values that contains special characters like letters with accents, the `ñ` and many other characters that are passed to prepared statement like string.

Fix #574