### PR TITLE
Issue #536 - prevent panic when starting a transaction after making connection and shutting down SQL server 

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -285,7 +285,7 @@ func (c *Conn) begin(ctx context.Context, tdsIsolation isoLevel) (tx driver.Tx, 
 	}
 	tx, err = c.processBeginResponse(ctx)
 	if err != nil {
-		return nil, c.checkBadConn(err)
+		return nil, err
 	}
 	return
 }


### PR DESCRIPTION
Fixes issue #536

The issue occurs when [sql.DB#BeginTx(context.Context, *sql.TxOptions)](https://github.com/golang/go/blob/master/src/database/sql/sql.go#L1723) is called after SQL server connection is closed by, for example, shutting down SQL server by stopping its Docker container. See [sevasm/go-mssqldb-panic](https://github.com/sevasm/go-mssqldb-panic) for an example program that can reproduce the issue reliably.

The issue cannot be reproduced by closing the underlying transport of the connection as is done in a number of tests, e.g. [TestCommitTranError (conn.sess.buf.transport.Close())](https://github.com/denisenkom/go-mssqldb/blob/master/queries_test.go#L1101).

After closing the underlying transport and calling [sql.DB#BeginTx(context.Context, *sql.TxOptions)](https://github.com/golang/go/blob/master/src/database/sql/sql.go#L1723), [#sendBeginXact(*tdsBuffer, []headerStruct, isoLevel, string, bool)](https://github.com/denisenkom/go-mssqldb/blob/master/tran.go#L31) is eventually called, and due to the closed transport returns an error.

However, when the connection is closed by stopping the SQLServer container, this method instead returns `nil`, indicating no error. Instead, an error is later received by [mssql.Conn#simpleProcessResp(context.Context)](https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L203) on line [214](https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L214). There, checkBadConn is called on the error and the "checked" error is returned. Eventually it propagates up to [mssql.Conn#begin(context.Context, isoLevel)](https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L278) and is checked for a second time on line [288](https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L288), causing the panic as it's already "checked" and is already a `driver.ErrBadConn` as indicated by the error message.

Because of how [mssql.Conn#simpleProcessResp(context.Context)](https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L203) and [mssql.Conn#processBeginResponse(context.Context)](https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L311) are implemented, I believe [mssql.Conn#begin(context.Context, isoLevel)](https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L278) can only ever receive errors that are already "checked".

I can confirm that all tests pass after making the change.