### PR TITLE
update the build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,16 +29,16 @@ environment:
     - SQLINSTANCE: SQL2012SP1
     - SQLINSTANCE: SQL2008R2SP2
 
-    #  Go 1.14 and SQL2019 are available on the Visual Studio 2019 image only
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GOVERSION: 114
-      SQLINSTANCE: SQL2017
+    #  Go 1.14+ and SQL2019 are available on the Visual Studio 2019 image only
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GOVERSION: 114
       SQLINSTANCE: SQL2019
-
-    # TODO: add Go 1.15
-    # the latest version of Go is 1.15, but it is not available on AppVeyor (2020-08-28)
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GOVERSION: 115
+      SQLINSTANCE: SQL2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GOVERSION: 115
+      SQLINSTANCE: SQL2017
 
 install:
   - set GOROOT=c:\go%GOVERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 1.0.{build}
 
-os: Windows Server 2012 R2
+image:
+  - Visual Studio 2015
 
 clone_folder: c:\gopath\src\github.com\denisenkom\go-mssqldb
 
@@ -9,21 +10,36 @@ environment:
   HOST: localhost
   SQLUSER: sa
   SQLPASSWORD: Password12!
-  DATABASE: test  
-  GOVERSION: 111
+  DATABASE: test
+  GOVERSION: 113
   matrix:
     - GOVERSION: 18
-      SQLINSTANCE: SQL2016
+      SQLINSTANCE: SQL2017
     - GOVERSION: 19
-      SQLINSTANCE: SQL2016
+      SQLINSTANCE: SQL2017
     - GOVERSION: 110
-      SQLINSTANCE: SQL2016
+      SQLINSTANCE: SQL2017
     - GOVERSION: 111
-      SQLINSTANCE: SQL2016
+      SQLINSTANCE: SQL2017
+    - GOVERSION: 112
+      SQLINSTANCE: SQL2017
+    - SQLINSTANCE: SQL2017
+    - SQLINSTANCE: SQL2016
     - SQLINSTANCE: SQL2014
     - SQLINSTANCE: SQL2012SP1
     - SQLINSTANCE: SQL2008R2SP2
- 
+
+    #  Go 1.14 and SQL2019 are available on the Visual Studio 2019 image only
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GOVERSION: 114
+      SQLINSTANCE: SQL2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GOVERSION: 114
+      SQLINSTANCE: SQL2019
+
+    # TODO: add Go 1.15
+    # the latest version of Go is 1.15, but it is not available on AppVeyor (2020-08-28)
+
 install:
   - set GOROOT=c:\go%GOVERSION%
   - set PATH=%GOPATH%\bin;%GOROOT%\bin;%PATH%
@@ -35,15 +51,14 @@ build_script:
   - go build
 
 before_test:
-  # setup SQL Server 
-  - ps: | 
+  # setup SQL Server
+  - ps: |
       $instanceName = $env:SQLINSTANCE
       Start-Service "MSSQL`$$instanceName"
       Start-Service "SQLBrowser"
   - sqlcmd -S "(local)\%SQLINSTANCE%" -Q "Use [master]; CREATE DATABASE test;"
   - sqlcmd -S "(local)\%SQLINSTANCE%" -h -1 -Q "set nocount on; Select @@version"
   - pip install codecov
- 
 
 test_script:
   - go test -race -cpu 4 -coverprofile=coverage.txt -covermode=atomic

--- a/queries_test.go
+++ b/queries_test.go
@@ -585,6 +585,7 @@ func TestTwoQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal("First exec failed", err)
 	}
+	defer rows.Close()
 	if !rows.Next() {
 		t.Fatal("First query didn't return row")
 	}
@@ -595,10 +596,14 @@ func TestTwoQueries(t *testing.T) {
 	if i != 1 {
 		t.Fatalf("Wrong value returned %d, should be 1", i)
 	}
+	if rows.Next() {
+		t.Fatal("First query returns too many rows")
+	}
 
 	if rows, err = conn.Query("select 2"); err != nil {
 		t.Fatal("Second query failed", err)
 	}
+	defer rows.Close()
 	if !rows.Next() {
 		t.Fatal("Second query didn't return row")
 	}
@@ -607,6 +612,9 @@ func TestTwoQueries(t *testing.T) {
 	}
 	if i != 2 {
 		t.Fatalf("Wrong value returned %d, should be 2", i)
+	}
+	if rows.Next() {
+		t.Fatal("Second query returns too many rows")
 	}
 }
 
@@ -1463,6 +1471,7 @@ func TestColumnTypeIntrospection(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Query failed with unexpected error %s", err)
 		}
+		defer rows.Close()
 		ct, err := rows.ColumnTypes()
 		if err != nil {
 			t.Fatalf("Query failed with unexpected error %s", err)


### PR DESCRIPTION
- add SQL2017 and SQL2019
- add Go 1.12, 1.13, and 1.14

Tests fail with Go 1.12 or later, but it is not due to this pull request.
`go test` detects data race.

https://ci.appveyor.com/project/shogo82148/go-mssqldb/builds/34908425/job/vxdgjcwfpenv6889

```
Build started
git clone -q --branch=go1.15-is-released https://github.com/shogo82148/go-mssqldb.git c:\gopath\src\github.com\denisenkom\go-mssqldb
git checkout -qf de1c72fd830286d2a3f7aa18ce7fea11e21f4212
Running Install scripts
set GOROOT=c:\go%GOVERSION%
set PATH=%GOPATH%\bin;%GOROOT%\bin;%PATH%
go version
go version go1.14.6 windows/amd64
go env
set GO111MODULE=
set GOARCH=amd64
set GOBIN=
set GOCACHE=C:\Users\appveyor\AppData\Local\go-build
set GOENV=C:\Users\appveyor\AppData\Roaming\go\env
set GOEXE=.exe
set GOFLAGS=
set GOHOSTARCH=amd64
set GOHOSTOS=windows
set GOINSECURE=
set GONOPROXY=
set GONOSUMDB=
set GOOS=windows
set GOPATH=c:\gopath
set GOPRIVATE=
set GOPROXY=https://proxy.golang.org,direct
set GOROOT=c:\go114
set GOSUMDB=sum.golang.org
set GOTMPDIR=
set GOTOOLDIR=c:\go114\pkg\tool\windows_amd64
set GCCGO=gccgo
set AR=ar
set CC=gcc
set CXX=g++
set CGO_ENABLED=1
set GOMOD=C:\gopath\src\github.com\denisenkom\go-mssqldb\go.mod
set CGO_CFLAGS=-g -O2
set CGO_CPPFLAGS=
set CGO_CXXFLAGS=-g -O2
set CGO_FFLAGS=-g -O2
set CGO_LDFLAGS=-g -O2
set PKG_CONFIG=pkg-config
set GOGCCFLAGS=-m64 -mthreads -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=C:\Users\appveyor\AppData\Local\Temp\1\go-build932034126=/tmp/go-build -gno-record-gcc-switches
go get -u github.com/golang-sql/civil
go: downloading github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe
go build
$instanceName = $env:SQLINSTANCE
Start-Service "MSSQL`$$instanceName"
Start-Service "SQLBrowser"
sqlcmd -S "(local)\%SQLINSTANCE%" -Q "Use [master]; CREATE DATABASE test;"
Changed database context to 'master'.
sqlcmd -S "(local)\%SQLINSTANCE%" -h -1 -Q "set nocount on; Select @@version"
Microsoft SQL Server 2019 (RTM) - 15.0.2000.5 (X64) 
	Sep 24 2019 13:48:23 
	Copyright (C) 2019 Microsoft Corporation
	Developer Edition (64-bit) on Windows Server 2019 Datacenter 10.0 <X64> (Build 17763: ) (Hypervisor)
                                                                                
pip install codecov
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Collecting codecov
  Downloading codecov-2.1.9-py2.py3-none-any.whl (16 kB)
Collecting requests>=2.7.9
  Downloading requests-2.24.0-py2.py3-none-any.whl (61 kB)
Collecting coverage
  Downloading coverage-5.2.1-cp27-cp27m-win32.whl (205 kB)
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
  Downloading urllib3-1.25.10-py2.py3-none-any.whl (127 kB)
Collecting certifi>=2017.4.17
  Downloading certifi-2020.6.20-py2.py3-none-any.whl (156 kB)
Collecting chardet<4,>=3.0.2
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Collecting idna<3,>=2.5
  Downloading idna-2.10-py2.py3-none-any.whl (58 kB)
Installing collected packages: urllib3, certifi, chardet, idna, requests, coverage, codecov
Successfully installed certifi-2020.6.20 chardet-3.0.4 codecov-2.1.9 coverage-5.2.1 idna-2.10 requests-2.24.0 urllib3-1.25.10
WARNING: You are using pip version 20.0.2; however, version 20.2.2 is available.
You should consider upgrading via the 'c:\python27\python.exe -m pip install --upgrade pip' command.
go test -race -cpu 4 -coverprofile=coverage.txt -covermode=atomic
2020/08/28 14:52:39 initiating response reading
2020/08/28 14:52:39 got token tokenLoginAck
2020/08/28 14:52:39 got token tokenEnvChange
2020/08/28 14:52:39 got token tokenDone
2020/08/28 14:52:39 got DONE or DONEPROC status=0
2020/08/28 14:52:39 response finished
2020/08/28 14:52:39 
SET XACT_ABORT ON; -- 16384
SET ANSI_NULLS ON; -- 32
SET ARITHIGNORE ON; -- 128
2020/08/28 14:52:39 initiating response reading
2020/08/28 14:52:39 got token tokenEnvChange
2020/08/28 14:52:39 got token tokenDone
2020/08/28 14:52:39 got DONE or DONEPROC status=1
2020/08/28 14:52:39 got token tokenDone
2020/08/28 14:52:39 got DONE or DONEPROC status=1
2020/08/28 14:52:39 got token tokenDone
2020/08/28 14:52:39 got DONE or DONEPROC status=0
2020/08/28 14:52:39 response finished
2020/08/28 14:52:39 
select Options = @@OPTIONS;
2020/08/28 14:52:39 initiating response reading
2020/08/28 14:52:39 got token tokenColMetadata
2020/08/28 14:52:39 got token tokenRow
2020/08/28 14:52:39 got token tokenDone
2020/08/28 14:52:39 got DONE or DONEPROC status=16
2020/08/28 14:52:39 (1 row(s) affected)
2020/08/28 14:52:39 response finished
==================
WARNING: DATA RACE
Read at 0x00c0000ee4c3 by goroutine 68:
  testing.(*common).logDepth()
      c:/go114/src/testing/testing.go:710 +0xae
  testing.(*common).log()
      c:/go114/src/testing/testing.go:703 +0x96
  testing.(*common).Logf()
      c:/go114/src/testing/testing.go:749 +0x28
  github.com/denisenkom/go-mssqldb.testLogger.Printf()
      C:/gopath/src/github.com/denisenkom/go-mssqldb/tds_test.go:220 +0x73
  github.com/denisenkom/go-mssqldb.optionalLogger.Printf()
      C:/gopath/src/github.com/denisenkom/go-mssqldb/log.go:18 +0xb5
  github.com/denisenkom/go-mssqldb.processSingleResponse()
      C:/gopath/src/github.com/denisenkom/go-mssqldb/token.go:619 +0x1e1d
Previous write at 0x00c0000ee4c3 by goroutine 38:
  testing.tRunner.func1()
      c:/go114/src/testing/testing.go:1025 +0x46e
  testing.tRunner()
      c:/go114/src/testing/testing.go:1043 +0x214
Goroutine 68 (running) created at:
  github.com/denisenkom/go-mssqldb.processResponse()
      C:/gopath/src/github.com/denisenkom/go-mssqldb/token.go:808 +0x28c
Goroutine 38 (running) created at:
  testing.(*T).Run()
      c:/go114/src/testing/testing.go:1090 +0x707
  testing.runTests.func1()
      c:/go114/src/testing/testing.go:1334 +0xad
  testing.tRunner()
      c:/go114/src/testing/testing.go:1039 +0x1f2
  testing.runTests()
      c:/go114/src/testing/testing.go:1332 +0x52e
  testing.(*M).Run()
      c:/go114/src/testing/testing.go:1249 +0x446
  main.main()
      _testmain.go:362 +0x33e
==================
2020/08/28 14:52:55 [{Hello} {World} {TVP}]
FAIL
coverage: 76.3% of statements
exit status 1
FAIL	github.com/denisenkom/go-mssqldb	16.826s
Command exited with code 1
```