### PR TITLE
passing context to the tokenprovider fun

### DIFF
--- a/accesstokenconnector.go
+++ b/accesstokenconnector.go
@@ -16,13 +16,13 @@ var _ driver.Connector = &accessTokenConnector{}
 type accessTokenConnector struct {
 	Connector
 
-	accessTokenProvider func() (string, error)
+	accessTokenProvider func(ctx context.Context) (string, error)
 }
 
 // NewAccessTokenConnector creates a new connector from a DSN and a token provider.
 // The token provider func will be called when a new connection is requested and should return a valid access token.
 // The returned connector may be used with sql.OpenDB.
-func NewAccessTokenConnector(dsn string, tokenProvider func() (string, error)) (driver.Connector, error) {
+func NewAccessTokenConnector(dsn string, tokenProvider func(ctx context.Context) (string, error)) (driver.Connector, error) {
 	if tokenProvider == nil {
 		return nil, errors.New("mssql: tokenProvider cannot be nil")
 	}
@@ -42,7 +42,7 @@ func NewAccessTokenConnector(dsn string, tokenProvider func() (string, error)) (
 // Connect returns a new database connection
 func (c *accessTokenConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	var err error
-	c.Connector.params.fedAuthAccessToken, err = c.accessTokenProvider()
+	c.Connector.params.fedAuthAccessToken, err = c.accessTokenProvider(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("mssql: error retrieving access token: %+v", err)
 	}

--- a/accesstokenconnector_test.go
+++ b/accesstokenconnector_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestNewAccessTokenConnector(t *testing.T) {
 	dsn := "Server=server.database.windows.net;Database=db"
-	tp := func() (string, error) { return "token", nil }
+	tp := func(ctx context.Context) (string, error) { return "token", nil }
 	type args struct {
 		dsn           string
-		tokenProvider func() (string, error)
+		tokenProvider func(ctx context.Context) (string, error)
 	}
 	tests := []struct {
 		name    string
@@ -44,7 +44,7 @@ func TestNewAccessTokenConnector(t *testing.T) {
 				if tc.accessTokenProvider == nil {
 					return fmt.Errorf("Expected tokenProvider to not be nil")
 				}
-				t, err := tc.accessTokenProvider()
+				t, err := tc.accessTokenProvider(context.TODO())
 				if t != "token" || err != nil {
 					return fmt.Errorf("Unexpected results from tokenProvider: %v, %v", t, err)
 				}
@@ -80,7 +80,7 @@ func TestNewAccessTokenConnector(t *testing.T) {
 func TestAccessTokenConnectorFailsToConnectIfNoAccessToken(t *testing.T) {
 	errorText := "This is a test"
 	dsn := "Server=server.database.windows.net;Database=db"
-	tp := func() (string, error) { return "", errors.New(errorText) }
+	tp := func(ctx context.Context) (string, error) { return "", errors.New(errorText) }
 	sut, err := NewAccessTokenConnector(dsn, tp)
 	if err != nil {
 		t.Fatalf("expected err==nil, but got %+v", err)

--- a/examples/azuread-accesstoken/managed_identity.go
+++ b/examples/azuread-accesstoken/managed_identity.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
@@ -63,7 +64,7 @@ func main() {
 	fmt.Printf("bye\n")
 }
 
-func getMSITokenProvider() (func() (string, error), error) {
+func getMSITokenProvider() (func(ctx context.Context) (string, error), error) {
 	msiEndpoint, err := adal.GetMSIEndpoint()
 	if err != nil {
 		return nil, err
@@ -74,8 +75,8 @@ func getMSITokenProvider() (func() (string, error), error) {
 		return nil, err
 	}
 
-	return func() (string, error) {
-		msi.EnsureFresh()
+	return func(ctx context.Context) (string, error) {
+		msi.EnsureFreshContext(ctx)
 		token := msi.OAuthToken()
 		return token, nil
 	}, nil


### PR DESCRIPTION
the tokenprovider func is chanigng in this PR: 
https://github.com/denisenkom/go-mssqldb/pull/547

Seeing as it might possibly take some time to land the PR in master, I'd like to provide a simpler update to the tokenprovider func and pass it the context.