### PR TITLE
Make sure channels are closed and close Rows and Stmt

### DIFF
--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -108,6 +108,10 @@ func TestBulkcopy(t *testing.T) {
 	t.Log("Preparing copy in statement")
 
 	stmt, err := conn.PrepareContext(ctx, CopyIn(tableName, BulkOptions{}, columns...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
 
 	for i := 0; i < 10; i++ {
 		t.Logf("Executing copy in statement %d time with %d values", i+1, len(values))

--- a/datetimeoffset_example_test.go
+++ b/datetimeoffset_example_test.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"time"
 
+	mssql "github.com/denisenkom/go-mssqldb"
 	"github.com/golang-sql/civil"
-	"github.com/denisenkom/go-mssqldb"
 )
 
 // This example shows how to insert and retrieve date and time types data
@@ -49,6 +49,8 @@ func insertDateTime(db *sql.DB) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer stmt.Close()
+
 	tin, err := time.Parse(time.RFC3339, "2006-01-02T22:04:05.787-07:00")
 	if err != nil {
 		log.Fatal(err)

--- a/lastinsertid_example_test.go
+++ b/lastinsertid_example_test.go
@@ -55,6 +55,7 @@ func ExampleLastInsertId() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer rows.Close()
 	var lastInsertId1 int64
 	for rows.Next() {
 		rows.Scan(&lastInsertId1)

--- a/mssql.go
+++ b/mssql.go
@@ -209,11 +209,11 @@ func (c *Conn) simpleProcessResp(ctx context.Context) error {
 	for tok := range tokchan {
 		switch token := tok.(type) {
 		case doneStruct:
-			if token.isError() && err != nil {
+			if token.isError() && err == nil {
 				err = c.checkBadConn(token.getError())
 			}
 		case error:
-			if err != nil {
+			if err == nil {
 				err = c.checkBadConn(token)
 			}
 		}

--- a/mssql.go
+++ b/mssql.go
@@ -666,14 +666,19 @@ func (s *Stmt) processExec(ctx context.Context) (res driver.Result, err error) {
 			if token.Status&doneCount != 0 {
 				rowCount += int64(token.RowCount)
 			}
-			if token.isError() {
-				return nil, token.getError()
+			if token.isError() && err == nil {
+				err = token.getError()
 			}
 		case ReturnStatus:
 			s.c.setReturnStatus(token)
 		case error:
-			return nil, token
+			if err == nil {
+				err = token
+			}
 		}
+	}
+	if err != nil {
+		return nil, err
 	}
 	return &Result{s.c, rowCount}, nil
 }

--- a/mssql.go
+++ b/mssql.go
@@ -621,12 +621,22 @@ loop:
 		case doneStruct:
 			if token.isError() {
 				cancel()
+
+				// make sure tokchan is closed
+				for range tokchan {
+				}
+
 				return nil, s.c.checkBadConn(token.getError())
 			}
 		case ReturnStatus:
 			s.c.setReturnStatus(token)
 		case error:
 			cancel()
+
+			// make sure tokchan is closed
+			for range tokchan {
+			}
+
 			return nil, s.c.checkBadConn(token)
 		}
 	}

--- a/queries_go110_test.go
+++ b/queries_go110_test.go
@@ -207,6 +207,8 @@ func TestReturnStatusWithQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rows.Close()
+
 	var str string
 	for rows.Next() {
 		err = rows.Scan(&str)

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -60,6 +60,7 @@ END;
 		if err != nil {
 			t.Error(err)
 		}
+		defer rows.Close()
 		// reading first row
 		if !rows.Next() {
 			t.Error("Next returned false")
@@ -947,10 +948,10 @@ with
 					}
 					return
 				}
+				defer rows.Close()
 				for rows.Next() {
 					// Nothing.
 				}
-				rows.Close()
 			})
 		}
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -622,8 +622,9 @@ func TestError(t *testing.T) {
 	conn := open(t)
 	defer conn.Close()
 
-	_, err := conn.Query("exec bad")
+	row, err := conn.Query("exec bad")
 	if err == nil {
+		defer row.Close()
 		t.Fatal("Query should fail")
 	}
 
@@ -645,6 +646,7 @@ func TestQueryNoRows(t *testing.T) {
 	if rows, err = conn.Query("create table #abc (fld int)"); err != nil {
 		t.Fatal("Query failed", err)
 	}
+	defer rows.Close()
 	if rows.Next() {
 		t.Fatal("Query shoulnd't return any rows")
 	}
@@ -697,6 +699,7 @@ func TestOrderBy(t *testing.T) {
 	if err != nil {
 		t.Fatal("Query failed", err)
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var fld1 int32
@@ -880,7 +883,9 @@ func TestUniqueIdentifierParam(t *testing.T) {
 func TestBigQuery(t *testing.T) {
 	conn := open(t)
 	defer conn.Close()
-	rows, err := conn.Query(`WITH n(n) AS
+
+	func() {
+		rows, err := conn.Query(`WITH n(n) AS
 		(
 		    SELECT 1
 		    UNION ALL
@@ -888,13 +893,15 @@ func TestBigQuery(t *testing.T) {
 		)
 		SELECT n, @@version FROM n ORDER BY n
 		OPTION (MAXRECURSION 10000);`)
-	if err != nil {
-		t.Fatal("cannot exec query", err)
-	}
-	rows.Next()
-	rows.Close()
+		if err != nil {
+			t.Fatal("cannot exec query", err)
+		}
+		defer rows.Close()
+		rows.Next()
+	}()
+
 	var res int
-	err = conn.QueryRow("select 0").Scan(&res)
+	err := conn.QueryRow("select 0").Scan(&res)
 	if err != nil {
 		t.Fatal("cannot scan value", err)
 	}
@@ -1040,17 +1047,20 @@ func TestConnectionClosing(t *testing.T) {
 			return
 		}
 
-		stmt, err := pool.Query("select 1")
-		if err != nil {
-			t.Fatalf("Query failed with unexpected error %s", err)
-		}
-		for stmt.Next() {
-			var val interface{}
-			err := stmt.Scan(&val)
+		func() {
+			rows, err := pool.Query("select 1")
 			if err != nil {
 				t.Fatalf("Query failed with unexpected error %s", err)
 			}
-		}
+			defer rows.Close()
+			for rows.Next() {
+				var val interface{}
+				err := rows.Scan(&val)
+				if err != nil {
+					t.Fatalf("Query failed with unexpected error %s", err)
+				}
+			}
+		}()
 	}
 }
 
@@ -1537,6 +1547,7 @@ func TestColumnIntrospection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Query failed with unexpected error %s", err)
 	}
+	defer rows.Close()
 
 	ct, err := rows.ColumnTypes()
 	if err != nil {
@@ -1596,19 +1607,27 @@ func TestContext(t *testing.T) {
 		t.Errorf("BeginTx failed with unexpected error %s", err)
 		return
 	}
-	rows, err := tx.QueryContext(ctx, "DBCC USEROPTIONS")
-	properties := make(map[string]string)
-	for rows.Next() {
-		var name, value string
-		if err = rows.Scan(&name, &value); err != nil {
-			t.Errorf("Scan failed with unexpected error %s", err)
-		}
-		properties[name] = value
-	}
+	defer tx.Rollback()
 
-	if properties["isolation level"] != "serializable" {
-		t.Errorf("Expected isolation level to be serializable but it is %s", properties["isolation level"])
-	}
+	// check the isolation level
+	func() {
+		rows, err := tx.QueryContext(ctx, "DBCC USEROPTIONS")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		properties := make(map[string]string)
+		for rows.Next() {
+			var name, value string
+			if err = rows.Scan(&name, &value); err != nil {
+				t.Errorf("Scan failed with unexpected error %s", err)
+			}
+			properties[name] = value
+		}
+		if properties["isolation level"] != "serializable" {
+			t.Errorf("Expected isolation level to be serializable but it is %s", properties["isolation level"])
+		}
+	}()
 
 	row := tx.QueryRowContext(ctx, "select 1")
 	var val int64
@@ -1625,11 +1644,12 @@ func TestContext(t *testing.T) {
 		return
 	}
 
-	_, err = tx.PrepareContext(ctx, "select 1")
+	stmt, err := tx.PrepareContext(ctx, "select 1")
 	if err != nil {
 		t.Errorf("PrepareContext failed with unexpected error %s", err)
 		return
 	}
+	defer stmt.Close()
 }
 
 func TestBeginTxtReadOnlyNotSupported(t *testing.T) {
@@ -1674,6 +1694,7 @@ func TestConn_BeginTx(t *testing.T) {
 	if err != nil {
 		t.Fatal("select failed with error", err)
 	}
+	defer rows.Close()
 	values := []int64{}
 	for rows.Next() {
 		var val int64

--- a/queries_test.go
+++ b/queries_test.go
@@ -936,6 +936,7 @@ func TestIgnoreEmptyResults(t *testing.T) {
 	if err != nil {
 		t.Fatal("Query failed", err.Error())
 	}
+	defer rows.Close()
 	if !rows.Next() {
 		t.Fatal("Query didn't return row")
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -1807,6 +1807,7 @@ func TestQueryCancelLowLevel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Query failed with error %v", err)
 	}
+	defer rows.Close()
 
 	values := []driver.Value{nil}
 	err = rows.Next(values)

--- a/tds.go
+++ b/tds.go
@@ -1016,6 +1016,11 @@ initiate_connection:
 				if token.isError() {
 					return nil, fmt.Errorf("Login error: %s", token.getError())
 				}
+
+				// make sure tokchan is closed
+				for range tokchan {
+				}
+
 				goto loginEnd
 			}
 		}

--- a/tds_test.go
+++ b/tds_test.go
@@ -337,20 +337,22 @@ func TestMultipleQueryClose(t *testing.T) {
 	}
 	defer stmt.Close()
 
-	rows, err := stmt.Query()
-	if err != nil {
-		t.Error("Query failed:", err.Error())
-		return
-	}
-	rows.Close()
+	func() {
+		rows, err := stmt.Query()
+		if err != nil {
+			t.Fatal("Query failed:", err.Error())
+		}
+		defer rows.Close()
+	}()
 
-	rows, err = stmt.Query()
-	if err != nil {
-		t.Error("Query failed:", err.Error())
-		return
-	}
-	defer rows.Close()
-	checkSimpleQuery(rows, t)
+	func() {
+		rows, err := stmt.Query()
+		if err != nil {
+			t.Fatal("Query failed:", err.Error())
+		}
+		defer rows.Close()
+		checkSimpleQuery(rows, t)
+	}()
 }
 
 func TestPing(t *testing.T) {

--- a/tds_test.go
+++ b/tds_test.go
@@ -145,6 +145,11 @@ func TestSendSqlBatch(t *testing.T) {
 
 	ch := make(chan tokenStruct, 5)
 	go processResponse(context.Background(), conn, ch, nil)
+	defer func() {
+		// make share ch is closed
+		for range ch {
+		}
+	}()
 
 	var lastRow []interface{}
 loop:

--- a/token.go
+++ b/token.go
@@ -814,8 +814,16 @@ func processResponse(ctx context.Context, sess *tdsSession, ch chan tokenStruct,
 			case parseRespIterContinue:
 				// Nothing, continue to next token.
 			case parseRespIterNext:
+				// make sure tokChan is closed
+				for range tokChan {
+				}
+
 				break tokensLoop
 			case parseRespIterDone:
+				// make sure tokChan is closed
+				for range tokChan {
+				}
+
 				return
 			}
 		}

--- a/tvp_go19_db_test.go
+++ b/tvp_go19_db_test.go
@@ -303,10 +303,10 @@ func TestTVP(t *testing.T) {
 		sql.Named("param2", tvpTypeEmpty),
 		sql.Named("param3", "test"),
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rows.Close()
 
 	var result1 []TvptableRow
 	for rows.Next() {
@@ -560,10 +560,10 @@ func TestTVP_WithTag(t *testing.T) {
 		sql.Named("param2", tvpTypeEmpty),
 		sql.Named("param3", "test"),
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rows.Close()
 
 	var result1 []TvptableRowWithSkipTag
 	for rows.Next() {
@@ -690,17 +690,16 @@ func TestTVPSchema(t *testing.T) {
 		sql.Named("param1", tvpType),
 	)
 	if err != nil {
-		log.Println(err)
-		return
+		t.Fatal(err)
 	}
+	defer rows.Close()
 
 	tvpResult := make([]TvpExample, 0)
 	for rows.Next() {
 		tvpExemple := TvpExample{}
 		err = rows.Scan(&tvpExemple.Message)
 		if err != nil {
-			log.Println(err)
-			return
+			t.Fatal(err)
 		}
 		tvpResult = append(tvpResult, tvpExemple)
 	}


### PR DESCRIPTION
This pull request may fixes races reported by https://github.com/denisenkom/go-mssqldb/pull/596#issue-475458766

It looks that [processResponse](https://github.com/denisenkom/go-mssqldb/blob/1e08a3fab20416d36c5fe538e75939710003f611/token.go#L788) and [processSingleResponse](https://github.com/denisenkom/go-mssqldb/blob/1e08a3fab20416d36c5fe538e75939710003f611/token.go#L558) are not safe to call concurrently.
So, callers of these functions must wait until the functions finish by making sure channels are closed.

In addition, we should call `(*Rows).Close` correctly, because `(*Rows).Close` makes sure the channels created by (*Stmt).Query are closed.
