### PR TITLE
Added NullUniqueIdentifier struct to work with GUIDs that can be null

### DIFF
--- a/nulluniqueidentifier.go
+++ b/nulluniqueidentifier.go
@@ -1,0 +1,21 @@
+package mssql
+
+// NullUniqueIdentifier represents a GUID that may be null.
+// NullUniqueIdentifier implements the Scanner interface so it can be used as a scan destination.
+type NullUniqueIdentifier struct {
+	UniqueIdentifier UniqueIdentifier
+	Valid            bool
+}
+
+// Scan implements the Scanner interface.
+func (nui *NullUniqueIdentifier) Scan(v interface{}) error {
+
+	if v == nil {
+
+		nui.Valid = false
+		return nil
+	}
+
+	nui.Valid = true
+	return nui.UniqueIdentifier.Scan(v)
+}

--- a/nulluniqueidentifier.go
+++ b/nulluniqueidentifier.go
@@ -16,6 +16,24 @@ func (nui *NullUniqueIdentifier) Scan(v interface{}) error {
 		return nil
 	}
 
+	err := nui.UniqueIdentifier.Scan(v)
+	if err != nil {
+
+		nui.Valid = false
+		return nil
+	}
+
 	nui.Valid = true
-	return nui.UniqueIdentifier.Scan(v)
+	return nil
+}
+
+// String returns the UniqueIdentifier value
+func (nui NullUniqueIdentifier) String() string {
+
+	if !nui.Valid {
+
+		return ""
+	}
+
+	return nui.UniqueIdentifier.String()
 }

--- a/nulluniqueidentifier_test.go
+++ b/nulluniqueidentifier_test.go
@@ -1,0 +1,56 @@
+package mssql
+
+import "testing"
+
+func TestNullUniqueIdentifier(t *testing.T) {
+	dbUUID := UniqueIdentifier{0x67, 0x45, 0x23, 0x01,
+		0xAB, 0x89,
+		0xEF, 0xCD,
+		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+	}
+
+	uuid := UniqueIdentifier{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
+
+	t.Run("Scan", func(t *testing.T) {
+
+		t.Run("[]byte", func(t *testing.T) {
+
+			var nui NullUniqueIdentifier
+			if err := nui.Scan(dbUUID[:]); err != nil {
+
+				t.Fatal(err)
+			}
+			if nui.UniqueIdentifier != uuid {
+
+				t.Errorf("bytes not swapped correctly: got %q; want %q", nui.UniqueIdentifier, uuid)
+			}
+		})
+
+		t.Run("string", func(t *testing.T) {
+
+			var nui NullUniqueIdentifier
+			if err := nui.Scan(uuid.String()); err != nil {
+
+				t.Fatal(err)
+			}
+			if nui.UniqueIdentifier != uuid {
+
+				t.Errorf("bytes not swapped correctly: got %q; want %q", nui.UniqueIdentifier, uuid)
+			}
+		})
+
+		t.Run("nil", func(t *testing.T) {
+
+			var nui NullUniqueIdentifier
+			var null interface{}
+			if err := nui.Scan(null); err != nil {
+
+				t.Fatal(err)
+			}
+			if nui.Valid {
+
+				t.Errorf("Validity not correct: got %t; want false", nui.Valid)
+			}
+		})
+	})
+}

--- a/nulluniqueidentifier_test.go
+++ b/nulluniqueidentifier_test.go
@@ -53,4 +53,36 @@ func TestNullUniqueIdentifier(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("String", func(t *testing.T) {
+
+		t.Run("Empty string", func(t *testing.T) {
+
+			var nui NullUniqueIdentifier
+			var null interface{}
+			if err := nui.Scan(null); err != nil {
+
+				t.Fatal(err)
+			}
+
+			if str := nui.String(); str != "" {
+
+				t.Errorf("String invalid: got %s; want %s", str, `""`)
+			}
+		})
+
+		t.Run("String", func(t *testing.T) {
+
+			var nui NullUniqueIdentifier
+			if err := nui.Scan(dbUUID[:]); err != nil {
+
+				t.Fatal(err)
+			}
+
+			if str := nui.String(); str == "" {
+
+				t.Errorf("String invalid: got %s; want %s", "67452301-AB89-EFCD-0123-456789ABCDEF", str)
+			}
+		})
+	})
 }


### PR DESCRIPTION
I'm working with the excecution of stored procedures, if the execution generates an transaction the answer will include a GUID, if it do not generates an transaction it does not mean there is an error, so I can or can't receive an unique identifier, thats why I think would be nice to include this data type in this proyect.