### PR TITLE
Avoid keeping output parameters in the connection

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -234,7 +234,7 @@ func (b *Bulk) Done() (rowcount int64, err error) {
 
 	buf.FinishPacket()
 
-	reader := startReading(b.cn.sess, b.ctx, nil)
+	reader := startReading(b.cn.sess, b.ctx, nil, nil)
 	err = reader.iterateResponse()
 	if err != nil {
 		return 0, b.cn.checkBadConn(err)

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -24,7 +24,7 @@ type MssqlResult = Result           // Deprecated: users should transition to th
 type MssqlRows = Rows               // Deprecated: users should transition to the new name when possible.
 type MssqlStmt = Stmt               // Deprecated: users should transition to the new name when possible.
 
-var _ driver.NamedValueChecker = &Conn{}
+var _ driver.NamedValueChecker = &Stmt{}
 
 // VarChar parameter types.
 type VarChar string
@@ -63,13 +63,13 @@ func convertInputParameter(val interface{}) (interface{}, error) {
 	}
 }
 
-func (c *Conn) CheckNamedValue(nv *driver.NamedValue) error {
+func (s *Stmt) CheckNamedValue(nv *driver.NamedValue) error {
 	switch v := nv.Value.(type) {
 	case sql.Out:
-		if c.outs == nil {
-			c.outs = make(map[string]interface{})
+		if s.outs == nil {
+			s.outs = make(map[string]interface{})
 		}
-		c.outs[nv.Name] = v.Dest
+		s.outs[nv.Name] = v.Dest
 
 		if v.Dest == nil {
 			return errors.New("destination is a nil pointer")
@@ -110,7 +110,7 @@ func (c *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 		return nil
 	case *ReturnStatus:
 		*v = 0 // By default the return value should be zero.
-		c.sess.returnStatus = v
+		s.returnStatus = v
 		return driver.ErrRemoveArgument
 	case TVP:
 		return nil

--- a/tds.go
+++ b/tds.go
@@ -141,7 +141,6 @@ type tdsSession struct {
 	log          optionalLogger
 	routedServer string
 	routedPort   uint16
-	returnStatus *ReturnStatus
 }
 
 const (
@@ -1148,7 +1147,7 @@ initiate_connection:
 	// SSPI and federated authentication scenarios may require multiple
 	// packet exchanges to complete the login sequence.
 	for loginAck := false; !loginAck; {
-		reader := startReading(&sess, ctx, nil)
+		reader := startReading(&sess, ctx, nil, nil)
 
 		for {
 			tok, err := reader.nextToken()
@@ -1223,10 +1222,4 @@ initiate_connection:
 		goto initiate_connection
 	}
 	return &sess, nil
-}
-
-func (sess *tdsSession) setReturnStatus(status ReturnStatus) {
-	if sess.returnStatus != nil {
-		*sess.returnStatus = status
-	}
 }

--- a/tds_test.go
+++ b/tds_test.go
@@ -168,7 +168,7 @@ func TestSendSqlBatch(t *testing.T) {
 		return
 	}
 
-	reader := startReading(conn, context.Background(), nil)
+	reader := startReading(conn, context.Background(), nil, nil)
 
 	err = reader.iterateResponse()
 	if err != nil {
@@ -591,7 +591,7 @@ func runBatch(t testing.TB, p connectParams) {
 		return
 	}
 
-	reader := startReading(conn, context.Background(), nil)
+	reader := startReading(conn, context.Background(), nil, nil)
 
 	err = reader.iterateResponse()
 	if err != nil {


### PR DESCRIPTION
This is to fix #654 

My knowledge on this driver is very limited, so I hope someone will be able to carefully review this.

What this does is:
- Implement `NamedValueChecker` in `Stmt` instead of `Conn`.
- Move output parameters (`outs` and `returnStatus`) from the `Conn` to the `Stmt`.
- When clearing output parameters, clear return status as well.
- Don't pass output parameters anymore to Begin/Commit/Rollback (I hope it's OK)
