### PR TITLE
Don't check Stmt.processExec errors twice

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -644,7 +644,7 @@ func (s *Stmt) exec(ctx context.Context, args []namedValue) (res driver.Result, 
 		return nil, s.c.checkBadConn(err)
 	}
 	if res, err = s.processExec(ctx); err != nil {
-		return nil, s.c.checkBadConn(err)
+		return nil, err
 	}
 	return
 }


### PR DESCRIPTION
Hello! 

I'm having the same `panic: driver.ErrBadConn in checkBadConn. This should not happen` as #536, except with `Stmt.exec`.

This is the same fix as #583.