### PR TITLE
Fix issue where login errors are not returned as mssql.Error

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1205,7 +1205,9 @@ initiate_connection:
 				loginAck = true
 			case doneStruct:
 				if token.isError() {
-					return nil, fmt.Errorf("login error: %s", token.getError())
+					tokenErr := token.getError()
+					tokenErr.Message = "login error: " + tokenErr.Message
+					return nil, tokenErr
 				}
 			case error:
 				return nil, fmt.Errorf("login error: %s", token.Error())


### PR DESCRIPTION
Fixes #653. 

Login errors don't get returned as `mssql.Error`. Instead they are returned as plain old `error`. This is due to a snippet in [tds.go](https://github.com/denisenkom/go-mssqldb/blob/master/tds.go#L1208) that removes the typing of the error message in order to preface the error with `"login error: "`. This PR adjusts that snippet to return `mssql.Error` while still maintaining the `"login error: "` prefix.