### PR TITLE
bulkcopy: allow int64 to varchar and nvarchar

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -373,6 +374,8 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 		switch val := val.(type) {
 		case string:
 			res.buffer = str2ucs2(val)
+		case int64:
+			res.buffer = []byte(strconv.FormatInt(val, 10))
 		case []byte:
 			res.buffer = val
 		default:
@@ -387,6 +390,8 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 			res.buffer = []byte(val)
 		case []byte:
 			res.buffer = val
+		case int64:
+			res.buffer = []byte(strconv.FormatInt(val, 10))
 		default:
 			err = fmt.Errorf("mssql: invalid type for varchar column: %T %s", val, val)
 			return

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -78,6 +78,8 @@ func TestBulkcopy(t *testing.T) {
 		{"test_varbinary_max", bin, nil},
 		{"test_binary", []byte("1"), nil},
 		{"test_binary_16", bin, nil},
+		{"test_intvarchar", 1234, "1234"},
+		{"test_intnvarchar", 1234, "1234"},
 	}
 
 	columns := make([]string, len(testValues))
@@ -270,6 +272,8 @@ func setupTable(ctx context.Context, t *testing.T, conn *sql.Conn, tableName str
 	[test_varbinary_max] VARBINARY(max) NOT NULL,
 	[test_binary] BINARY NOT NULL,
 	[test_binary_16] BINARY(16) NOT NULL,
+	[test_intvarchar] [varchar](4) NULL,
+	[test_intnvarchar] [varchar](4) NULL,
  CONSTRAINT [PK_` + tableName + `_id] PRIMARY KEY CLUSTERED
 (
 	[id] ASC


### PR DESCRIPTION
Allow insert from int64 to varchar and nvarchar in bulkcopy