### PR TITLE
Clear returnStatus between two queries on the same connection

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -235,7 +235,7 @@ func (b *Bulk) Done() (rowcount int64, err error) {
 
 	buf.FinishPacket()
 
-	reader := startReading(b.cn.sess, b.ctx, nil)
+	reader := startReading(b.cn.sess, b.ctx, outputs{})
 	err = reader.iterateResponse()
 	if err != nil {
 		return 0, b.cn.checkBadConn(err)

--- a/mssql.go
+++ b/mssql.go
@@ -173,7 +173,12 @@ type Conn struct {
 	processQueryText bool
 	connectionGood   bool
 
-	outs map[string]interface{}
+	outs outputs
+}
+
+type outputs struct {
+	params       map[string]interface{}
+	returnStatus *ReturnStatus
 }
 
 // IsValid satisfies the driver.Validator interface.
@@ -219,7 +224,7 @@ func (c *Conn) checkBadConn(err error) error {
 }
 
 func (c *Conn) clearOuts() {
-	c.outs = nil
+	c.outs = outputs{}
 }
 
 func (c *Conn) simpleProcessResp(ctx context.Context) error {
@@ -605,6 +610,8 @@ func convertOldArgs(args []driver.Value) []namedValue {
 }
 
 func (s *Stmt) Query(args []driver.Value) (driver.Rows, error) {
+	defer s.c.clearOuts()
+
 	return s.queryContext(context.Background(), convertOldArgs(args))
 }
 
@@ -649,7 +656,9 @@ loop:
 						return nil, s.c.checkBadConn(token.getError())
 					}
 				case ReturnStatus:
-					s.c.sess.setReturnStatus(token)
+					if reader.outs.returnStatus != nil {
+						*reader.outs.returnStatus = token
+					}
 				}
 			}
 		} else {
@@ -663,6 +672,8 @@ loop:
 }
 
 func (s *Stmt) Exec(args []driver.Value) (driver.Result, error) {
+	defer s.c.clearOuts()
+
 	return s.exec(context.Background(), convertOldArgs(args))
 }
 
@@ -757,7 +768,9 @@ func (rc *Rows) Next(dest []driver.Value) error {
 						return rc.stmt.c.checkBadConn(tokdata.getError())
 					}
 				case ReturnStatus:
-					rc.stmt.c.sess.setReturnStatus(tokdata)
+					if rc.reader.outs.returnStatus != nil {
+						*rc.reader.outs.returnStatus = tokdata
+					}
 				}
 			}
 
@@ -983,6 +996,8 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 }
 
 func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	defer s.c.clearOuts()
+
 	if !s.c.connectionGood {
 		return nil, driver.ErrBadConn
 	}
@@ -994,6 +1009,8 @@ func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 }
 
 func (s *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	defer s.c.clearOuts()
+
 	if !s.c.connectionGood {
 		return nil, driver.ErrBadConn
 	}

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -66,10 +66,10 @@ func convertInputParameter(val interface{}) (interface{}, error) {
 func (c *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 	switch v := nv.Value.(type) {
 	case sql.Out:
-		if c.outs == nil {
-			c.outs = make(map[string]interface{})
+		if c.outs.params == nil {
+			c.outs.params = make(map[string]interface{})
 		}
-		c.outs[nv.Name] = v.Dest
+		c.outs.params[nv.Name] = v.Dest
 
 		if v.Dest == nil {
 			return errors.New("destination is a nil pointer")
@@ -110,7 +110,7 @@ func (c *Conn) CheckNamedValue(nv *driver.NamedValue) error {
 		return nil
 	case *ReturnStatus:
 		*v = 0 // By default the return value should be zero.
-		c.sess.returnStatus = v
+		c.outs.returnStatus = v
 		return driver.ErrRemoveArgument
 	case TVP:
 		return nil

--- a/mssql_perf_test.go
+++ b/mssql_perf_test.go
@@ -210,6 +210,6 @@ func BenchmarkSelectParser(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		processSingleResponse(sess, ch, nil)
+		processSingleResponse(sess, ch, outputs{})
 	}
 }

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -1057,3 +1057,39 @@ func TestReturnStatus(t *testing.T) {
 		t.Errorf("expected status=2, got %d", rs)
 	}
 }
+
+func TestClearReturnStatus(t *testing.T) {
+	db := open(t)
+	defer db.Close()
+
+	ctx := context.TODO()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = conn.ExecContext(ctx, "CREATE PROC #get_answer AS RETURN 42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = conn.ExecContext(ctx, "CREATE PROC #get_half AS RETURN 21")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rs ReturnStatus
+
+	_, err = conn.ExecContext(ctx, "#get_answer", &rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = conn.ExecContext(ctx, "#get_half")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rs != 42 {
+		t.Errorf("expected status=42, got %d", rs)
+	}
+}

--- a/tds.go
+++ b/tds.go
@@ -143,7 +143,6 @@ type tdsSession struct {
 	log          optionalLogger
 	routedServer string
 	routedPort   uint16
-	returnStatus *ReturnStatus
 }
 
 const (
@@ -1190,7 +1189,7 @@ initiate_connection:
 	// SSPI and federated authentication scenarios may require multiple
 	// packet exchanges to complete the login sequence.
 	for loginAck := false; !loginAck; {
-		reader := startReading(&sess, ctx, nil)
+		reader := startReading(&sess, ctx, outputs{})
 
 		for {
 			tok, err := reader.nextToken()
@@ -1267,12 +1266,6 @@ initiate_connection:
 		goto initiate_connection
 	}
 	return &sess, nil
-}
-
-func (sess *tdsSession) setReturnStatus(status ReturnStatus) {
-	if sess.returnStatus != nil {
-		*sess.returnStatus = status
-	}
 }
 
 func resolveServerPort(port uint64) uint64 {

--- a/tds_test.go
+++ b/tds_test.go
@@ -173,7 +173,7 @@ func TestSendSqlBatch(t *testing.T) {
 		return
 	}
 
-	reader := startReading(conn, context.Background(), nil)
+	reader := startReading(conn, context.Background(), outputs{})
 
 	err = reader.iterateResponse()
 	if err != nil {
@@ -642,7 +642,7 @@ func runBatch(t testing.TB, p msdsn.Config) {
 		return
 	}
 
-	reader := startReading(conn, context.Background(), nil)
+	reader := startReading(conn, context.Background(), outputs{})
 
 	err = reader.iterateResponse()
 	if err != nil {

--- a/token.go
+++ b/token.go
@@ -758,13 +758,13 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs outputs) 
 }
 
 type tokenProcessor struct {
-	tokChan      chan tokenStruct
-	ctx          context.Context
-	sess         *tdsSession
-	outs         outputs
-	lastRow      []interface{}
-	rowCount     int64
-	firstError   error
+	tokChan    chan tokenStruct
+	ctx        context.Context
+	sess       *tdsSession
+	outs       outputs
+	lastRow    []interface{}
+	rowCount   int64
+	firstError error
 }
 
 func startReading(sess *tdsSession, ctx context.Context, outs outputs) *tokenProcessor {


### PR DESCRIPTION
Fixes #654.

- Add a new test to demonstrate that `returnStatus` is not cleared at all between two queries on the same connection.
- Move `returnStatus` to the same place as `outs` since they have the same scope, and a very similar usage.
- Gather `returnStatus` and `outs` into a struct, because we have to pass both to several functions, and also because I plan to propose a third member. `outs` becomes `outs.params`.
- Ensure `outs` is cleared even when we get an early error.
