### PR TITLE
Use RPC to execute a stored proc without parameters

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -465,7 +465,8 @@ func (s *Stmt) sendQuery(args []namedValue) (err error) {
 
 	reset := conn.resetSession
 	conn.resetSession = false
-	if len(args) == 0 {
+	isProc := isProc(s.query)
+	if len(args) == 0 && !isProc {
 		if err = sendSqlBatch72(conn.sess.buf, s.query, headers, reset); err != nil {
 			if conn.sess.logFlags&logErrors != 0 {
 				conn.sess.log.Printf("Failed to send SqlBatch with %v", err)
@@ -476,7 +477,7 @@ func (s *Stmt) sendQuery(args []namedValue) (err error) {
 	} else {
 		proc := sp_ExecuteSql
 		var params []param
-		if isProc(s.query) {
+		if isProc {
 			proc.name = s.query
 			params, _, err = s.makeRPCParams(args, true)
 			if err != nil {


### PR DESCRIPTION
This is a case where one could say "if it ain't broke don't fix it".

I noticed stored procedures are executed in SQL batches instead of RPC if we don't pass parameters.
This is a little inconsistent, but there doesn't seem to be a significant difference.
In both cases, SQL Server returns an error if you pass too many arguments.
I can't think of another difference.

Please note that a stored procedure can have default parameters, which means one could call it with or without arguments.
This means that `db.Exec("my_proc")` and `db.Exec("my_proc", 42)` both work, but one is an RPC while the other one is an SQL batch, until this PR is merged.