### PR TITLE
Support a few other cases in isProc

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -518,30 +518,38 @@ func isProc(s string) bool {
 	for _, r := range s {
 		rPrev = rn1
 		rn1 = r
-		switch r {
-		// No newlines or string sequences.
-		case '\n', '\r', '\'', ';':
-			return false
+		if st != escaped {
+			switch r {
+			// No newlines or string sequences.
+			case '\n', '\r', '\'', ';':
+				return false
+			}
 		}
 		switch st {
 		case outside:
 			switch {
-			case unicode.IsSpace(r):
-				return false
 			case r == '[':
 				st = escaped
-				continue
 			case r == ']' && rPrev == ']':
 				st = escaped
-				continue
 			case unicode.IsLetter(r):
 				st = text
+			case r == '_':
+				st = text
+			case r == '#':
+				st = text
+			case r == '.':
+			default:
+				return false
 			}
 		case text:
 			switch {
 			case r == '.':
 				st = outside
-				continue
+			case r == '[':
+				return false
+			case r == '(':
+				return false
 			case unicode.IsSpace(r):
 				return false
 			}
@@ -549,7 +557,6 @@ func isProc(s string) bool {
 			switch {
 			case r == ']':
 				st = outside
-				continue
 			}
 		}
 	}

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -23,12 +23,22 @@ func TestIsProc(t *testing.T) {
 		{"select 1;", false},
 		{"select 1", false},
 		{"[proc 1]", true},
-		{"[proc\n1]", false},
+		{"[proc\n1]", true},
 		{"schema.name", true},
 		{"[schema].[name]", true},
 		{"schema.[name]", true},
 		{"[schema].name", true},
 		{"schema.[proc name]", true},
+		{"db.schema.[proc name]", true},
+		{"db..[proc name]", true},
+		{"#temp_@_proc", true},
+		{"_temp.[_proc]", true},
+		{"raiserror(13000,1,1)", false},
+		{"select*from(@table)", false},
+		{"select[A]]]+1from[B]", false},
+		{"--proc", false},
+		{"[proc;]", true},
+		{" proc", false},
 	}
 
 	for _, item := range list {

--- a/tvp_go19_test.go
+++ b/tvp_go19_test.go
@@ -235,7 +235,7 @@ func TestTVPType_check(t *testing.T) {
 				TVPName:  "123.[Test]",
 				TVPValue: []fields{},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "TVP name is wrong",


### PR DESCRIPTION
This PR fixes `isProc` which detects if a string contains nothing but an object name.

It may still be a long way from the real lexer.

I had to fix 2 tests:
- Proc name `"[proc\n1]"` is valid
- Table type name `"123.[Test]"` is not
