### PR TITLE
Automatic Bad Connection Retry

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -238,7 +238,7 @@ func (b *Bulk) Done() (rowcount int64, err error) {
 	reader := startReading(b.cn.sess, b.ctx, nil)
 	err = reader.iterateResponse()
 	if err != nil {
-		return 0, b.cn.checkBadConn(err)
+		return 0, b.cn.checkBadConn(err, false)
 	}
 
 	return reader.rowCount, nil

--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package mssql
 
 import (
+	"database/sql/driver"
 	"fmt"
 )
 
@@ -20,6 +21,17 @@ type Error struct {
 	// All lists all errors that were received from first to last.
 	// This includes the last one, which is described in the other members.
 	All []Error
+	// badConn means the error allows the connection pool
+	// to drop the connection and immediately retry
+	// querying on another connection.
+	badConn bool
+}
+
+func (e Error) Unwrap() error {
+	if e.badConn {
+		return driver.ErrBadConn
+	}
+	return nil
 }
 
 func (e Error) Error() string {

--- a/error.go
+++ b/error.go
@@ -69,7 +69,7 @@ func streamErrorf(format string, v ...interface{}) StreamError {
 }
 
 func badStreamPanic(err error) {
-	panic(err)
+	panic(streamErrorf("%v", err))
 }
 
 func badStreamPanicf(format string, v ...interface{}) {

--- a/error.go
+++ b/error.go
@@ -74,3 +74,19 @@ func badStreamPanic(err error) {
 func badStreamPanicf(format string, v ...interface{}) {
 	panic(streamErrorf(format, v...))
 }
+
+// ServerError is returned when the server got a fatal error.
+//
+// To get the errors returned before the process was aborted,
+// use errors.As with an *mssql.Error.
+type ServerError struct {
+	sqlError Error
+}
+
+func (e ServerError) Error() string {
+	return "SQL Server had internal error"
+}
+
+func (e ServerError) Unwrap() error {
+	return e.sqlError
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,87 @@
+package mssql
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestServerError(t *testing.T) {
+
+	originalErr := Error{Message: "underlying error"}
+	sererErr := ServerError{sqlError: originalErr}
+
+	// Verify that error message is backwards compatible
+	oldMessage := "SQL Server had internal error"
+	if newMessage := sererErr.Error(); newMessage != oldMessage {
+		t.Fatalf("ServerError returned incompatible error message. Got '%s', wanted '%s'", newMessage, oldMessage)
+	}
+
+	// Verify that the underlying error is preserved
+	unwrappedErr := sererErr.Unwrap()
+	if underlyingErr, ok := unwrappedErr.(Error); !ok || underlyingErr.Message != originalErr.Message {
+		t.Fatalf("ServerError did not preserve wrapped error. Got '%+v', wanted '%+v'", unwrappedErr, originalErr)
+	}
+}
+
+func TestRetryableError(t *testing.T) {
+
+	originalErr := driver.ErrBadConn
+	retryableErr := RetryableError{err: originalErr}
+
+	// Verify that the error message matches the original error's
+	origMessage := originalErr.Error()
+	if wrappedMessage := retryableErr.Error(); wrappedMessage != origMessage {
+		t.Fatalf("RetryableError returned incorrect error message. Got '%s', wanted '%s'", wrappedMessage, origMessage)
+	}
+
+	// Verify that the underlying error is preserved
+	unwrappedErr := retryableErr.Unwrap()
+	if unwrappedErr != originalErr {
+		t.Fatalf("RetryableError did not preserve wrapped error. Got '%+v', wanted '%+v'", unwrappedErr, originalErr)
+	}
+
+	// Verify that underlying error is correctly recognized
+	if !retryableErr.Is(driver.ErrBadConn) {
+		t.Fatalf("RetryableError wrapping driver.ErrBadConn does not report it is a driver.ErrBadConn error")
+	}
+
+}
+
+func TestBadStreamPanic(t *testing.T) {
+
+	errMsg := "test error XYZ"
+	err := fmt.Errorf(errMsg)
+
+	defer func() {
+		r := recover()
+		if e, ok := r.(error); !ok || !strings.HasSuffix(e.Error(), errMsg) {
+			t.Fatalf("unexpected error recovered from panic: "+
+				"got error = '%+v', wanted error to end with '%s'", e, errMsg)
+		}
+	}()
+
+	badStreamPanic(err)
+
+	t.Fatalf("badStreamPanic did not panic as expected when passed %+v", err)
+}
+
+func TestBadStreamPanicf(t *testing.T) {
+
+	errfmt := "the error is '%s'"
+	errMsg := "test error XYZ"
+	expectedMsg := fmt.Sprintf(errfmt, errMsg)
+
+	defer func() {
+		r := recover()
+		if e, ok := r.(error); !ok || !strings.HasSuffix(e.Error(), expectedMsg) {
+			t.Fatalf("unexpected error recovered from panic: "+
+				"got error = '%+v', wanted error to end with '%s'", e, expectedMsg)
+		}
+	}()
+
+	badStreamPanicf(errfmt, errMsg)
+
+	t.Fatalf("badStreamPanicf did not panic as expected when passed %s", expectedMsg)
+}

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -310,6 +310,8 @@ func Parse(dsn string) (Config, map[string]string, error) {
 			f := "invalid disableRetry '%s': %s"
 			return p, params, fmt.Errorf(f, disableRetry, err.Error())
 		}
+	} else {
+		p.DisableRetry = disableRetryDefault
 	}
 
 	return p, params, nil
@@ -329,9 +331,7 @@ func (p Config) URL() *url.URL {
 	if p.Port > 0 {
 		host = fmt.Sprintf("%s:%d", p.Host, p.Port)
 	}
-	if p.DisableRetry {
-		q.Add("disableRetry", "true")
-	}
+	q.Add("disableRetry", fmt.Sprintf("%t", p.DisableRetry))
 	res := url.URL{
 		Scheme: "sqlserver",
 		Host:   host,

--- a/msdsn/conn_str_go118.go
+++ b/msdsn/conn_str_go118.go
@@ -1,0 +1,9 @@
+// +build go1.18
+
+package msdsn
+
+// disableRetryDefault is false for Go versions 1.18 and higher. This matches
+// the behavior requested in issue #586. A query that fails at the start due to
+// a bad connection is automatically retried. An error is returned only if the
+// query fails all of its retries.
+const disableRetryDefault bool = false

--- a/msdsn/conn_str_go118pre.go
+++ b/msdsn/conn_str_go118pre.go
@@ -1,0 +1,9 @@
+// +build !go1.18
+
+package msdsn
+
+// disableRetryDefault is true for versions of Go less than 1.18. This matches
+// the behavior requested in issue #275. A query that fails at the start due to
+// a bad connection is not retried. Instead, the detailed error is immediately
+// returned to the caller.
+const disableRetryDefault bool = true

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -75,6 +75,7 @@ func TestValidConnectionString(t *testing.T) {
 		{"disableretry=false", func(p Config) bool { return !p.DisableRetry }},
 		{"disableretry=1", func(p Config) bool { return p.DisableRetry }},
 		{"disableretry=0", func(p Config) bool { return !p.DisableRetry }},
+		{"", func(p Config) bool { return p.DisableRetry == disableRetryDefault }},
 
 		// those are supported currently, but maybe should not be
 		{"someparam", func(p Config) bool { return true }},

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -18,6 +18,7 @@ func TestInvalidConnectionString(t *testing.T) {
 		"trustservercertificate=invalid",
 		"failoverport=invalid",
 		"applicationintent=ReadOnly",
+		"disableretry=invalid",
 
 		// ODBC mode
 		"odbc:password={",
@@ -70,6 +71,10 @@ func TestValidConnectionString(t *testing.T) {
 		{"log=64;packet size=300", func(p Config) bool { return p.LogFlags == 64 && p.PacketSize == 512 }},
 		{"log=64;packet size=8192", func(p Config) bool { return p.LogFlags == 64 && p.PacketSize == 8192 }},
 		{"log=64;packet size=48000", func(p Config) bool { return p.LogFlags == 64 && p.PacketSize == 32767 }},
+		{"disableretry=true", func(p Config) bool { return p.DisableRetry }},
+		{"disableretry=false", func(p Config) bool { return !p.DisableRetry }},
+		{"disableretry=1", func(p Config) bool { return p.DisableRetry }},
+		{"disableretry=0", func(p Config) bool { return !p.DisableRetry }},
 
 		// those are supported currently, but maybe should not be
 		{"someparam", func(p Config) bool { return true }},
@@ -121,6 +126,12 @@ func TestValidConnectionString(t *testing.T) {
 		{"odbc:password={value}  ", func(p Config) bool {
 			return p.Password == "value"
 		}},
+		{"odbc:server=somehost;user id=someuser;password=somepass;disableretry=true", func(p Config) bool {
+			return p.Host == "somehost" && p.User == "someuser" && p.Password == "somepass" && p.DisableRetry
+		}},
+		{"odbc:server=somehost;user id=someuser;password=somepass; disableretry =  1 ", func(p Config) bool {
+			return p.Host == "somehost" && p.User == "someuser" && p.Password == "somepass" && p.DisableRetry
+		}},
 
 		// URL mode
 		{"sqlserver://somehost?connection+timeout=30", func(p Config) bool {
@@ -140,6 +151,12 @@ func TestValidConnectionString(t *testing.T) {
 		}},
 		{"sqlserver://someuser:foo%3A%2F%5C%21~%40;bar@somehost:1434/someinstance?connection+timeout=30", func(p Config) bool {
 			return p.Host == "somehost" && p.Port == 1434 && p.Instance == "someinstance" && p.User == "someuser" && p.Password == "foo:/\\!~@;bar" && p.ConnTimeout == 30*time.Second
+		}},
+		{"sqlserver://someuser@somehost?disableretry=true", func(p Config) bool {
+			return p.Host == "somehost" && p.Port == 0 && p.Instance == "" && p.User == "someuser" && p.Password == "" && p.DisableRetry
+		}},
+		{"sqlserver://someuser@somehost?connection+timeout=30&disableretry=1", func(p Config) bool {
+			return p.Host == "somehost" && p.Port == 0 && p.Instance == "" && p.User == "someuser" && p.Password == "" && p.ConnTimeout == 30*time.Second && p.DisableRetry
 		}},
 	}
 	for _, ts := range connStrings {

--- a/mssql.go
+++ b/mssql.go
@@ -214,11 +214,12 @@ func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 			badConn: mayRetry,
 		}
 	case Error:
-		err.badConn = mayRetry
+		err.badConn = mayRetry && !c.connectionGood
 		return err
 	}
 
 	if mayRetry && !c.connectionGood {
+		fmt.Println("returning ErrBadConn!")
 		return driver.ErrBadConn
 	}
 	return err

--- a/mssql.go
+++ b/mssql.go
@@ -181,23 +181,18 @@ func (c *Conn) IsValid() bool {
 	return c.connectionGood
 }
 
-func (c *Conn) checkBadConn(err error) error {
-	// this is a hack to address Issue #275
-	// we set connectionGood flag to false if
-	// error indicates that connection is not usable
-	// but we return actual error instead of ErrBadConn
-	// this will cause connection to stay in a pool
-	// but next request to this connection will return ErrBadConn
-
-	// it might be possible to revise this hack after
-	// https://github.com/golang/go/issues/20807
-	// is implemented
+// checkBadConn checks if an error means the connection must be dropped.
+// If canRetry is true, it will return driver.ErrBadConn to allow the
+// the connection pool to retry with another connection.
+func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 	switch err {
 	case nil:
 		return nil
+	case serverError:
+		c.connectionGood = false
 	case io.EOF:
 		c.connectionGood = false
-		return driver.ErrBadConn
+		err = driver.ErrBadConn
 	case driver.ErrBadConn:
 		// It is an internal programming error if driver.ErrBadConn
 		// is ever passed to this function. driver.ErrBadConn should
@@ -209,13 +204,14 @@ func (c *Conn) checkBadConn(err error) error {
 	switch err.(type) {
 	case net.Error:
 		c.connectionGood = false
-		return err
 	case StreamError:
 		c.connectionGood = false
-		return err
-	default:
-		return err
 	}
+
+	if mayRetry && !c.connectionGood {
+		return driver.ErrBadConn
+	}
+	return err
 }
 
 func (c *Conn) clearOuts() {
@@ -229,7 +225,7 @@ func (c *Conn) simpleProcessResp(ctx context.Context) error {
 	var resultError error
 	err := reader.iterateResponse()
 	if err != nil {
-		return c.checkBadConn(err)
+		return c.checkBadConn(err, false)
 	}
 	return resultError
 }
@@ -239,7 +235,7 @@ func (c *Conn) Commit() error {
 		return driver.ErrBadConn
 	}
 	if err := c.sendCommitRequest(); err != nil {
-		return c.checkBadConn(err)
+		return c.checkBadConn(err, true)
 	}
 	return c.simpleProcessResp(c.transactionCtx)
 }
@@ -266,7 +262,7 @@ func (c *Conn) Rollback() error {
 		return driver.ErrBadConn
 	}
 	if err := c.sendRollbackRequest(); err != nil {
-		return c.checkBadConn(err)
+		return c.checkBadConn(err, true)
 	}
 	return c.simpleProcessResp(c.transactionCtx)
 }
@@ -298,7 +294,7 @@ func (c *Conn) begin(ctx context.Context, tdsIsolation isoLevel) (tx driver.Tx, 
 	}
 	err = c.sendBeginRequest(ctx, tdsIsolation)
 	if err != nil {
-		return nil, c.checkBadConn(err)
+		return nil, c.checkBadConn(err, true)
 	}
 	tx, err = c.processBeginResponse(ctx)
 	if err != nil {
@@ -613,7 +609,7 @@ func (s *Stmt) queryContext(ctx context.Context, args []namedValue) (rows driver
 		return nil, driver.ErrBadConn
 	}
 	if err = s.sendQuery(args); err != nil {
-		return nil, s.c.checkBadConn(err)
+		return nil, s.c.checkBadConn(err, true)
 	}
 	return s.processQueryResponse(ctx)
 }
@@ -646,7 +642,7 @@ loop:
 					if token.isError() {
 						// need to cleanup cancellable context
 						cancel()
-						return nil, s.c.checkBadConn(token.getError())
+						return nil, s.c.checkBadConn(token.getError(), false)
 					}
 				case ReturnStatus:
 					s.c.sess.setReturnStatus(token)
@@ -655,7 +651,7 @@ loop:
 		} else {
 			// need to cleanup cancellable context
 			cancel()
-			return nil, s.c.checkBadConn(err)
+			return nil, s.c.checkBadConn(err, false)
 		}
 	}
 	res = &Rows{stmt: s, reader: reader, cols: cols, cancel: cancel}
@@ -671,7 +667,7 @@ func (s *Stmt) exec(ctx context.Context, args []namedValue) (res driver.Result, 
 		return nil, driver.ErrBadConn
 	}
 	if err = s.sendQuery(args); err != nil {
-		return nil, s.c.checkBadConn(err)
+		return nil, s.c.checkBadConn(err, true)
 	}
 	if res, err = s.processExec(ctx); err != nil {
 		return nil, err
@@ -684,7 +680,7 @@ func (s *Stmt) processExec(ctx context.Context) (res driver.Result, err error) {
 	s.c.clearOuts()
 	err = reader.iterateResponse()
 	if err != nil {
-		return nil, s.c.checkBadConn(err)
+		return nil, s.c.checkBadConn(err, false)
 	}
 	return &Result{s.c, reader.rowCount}, nil
 }
@@ -754,7 +750,7 @@ func (rc *Rows) Next(dest []driver.Value) error {
 					return nil
 				case doneStruct:
 					if tokdata.isError() {
-						return rc.stmt.c.checkBadConn(tokdata.getError())
+						return rc.stmt.c.checkBadConn(tokdata.getError(), false)
 					}
 				case ReturnStatus:
 					rc.stmt.c.sess.setReturnStatus(tokdata)
@@ -762,7 +758,7 @@ func (rc *Rows) Next(dest []driver.Value) error {
 			}
 
 		} else {
-			return rc.stmt.c.checkBadConn(err)
+			return rc.stmt.c.checkBadConn(err, false)
 		}
 	}
 }

--- a/mssql.go
+++ b/mssql.go
@@ -212,10 +212,9 @@ func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 	}
 
 	if !c.connectionGood && mayRetry && !c.connector.params.DisableRetry {
-		return RetryableError{
-			err: err,
-		}
+		return newRetryableError(err)
 	}
+
 	return err
 }
 

--- a/mssql.go
+++ b/mssql.go
@@ -188,8 +188,6 @@ func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 	switch err {
 	case nil:
 		return nil
-	case serverError:
-		c.connectionGood = false
 	case io.EOF:
 		c.connectionGood = false
 		err = driver.ErrBadConn
@@ -202,9 +200,7 @@ func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 	}
 
 	switch err.(type) {
-	case net.Error:
-		c.connectionGood = false
-	case StreamError:
+	case serverError, net.Error, StreamError:
 		c.connectionGood = false
 	}
 

--- a/mssql.go
+++ b/mssql.go
@@ -209,18 +209,16 @@ func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 		return err
 	case net.Error, StreamError:
 		c.connectionGood = false
-		return Error{
-			Message: err.Error(),
-			badConn: mayRetry,
-		}
 	case Error:
 		err.badConn = mayRetry && !c.connectionGood
 		return err
 	}
 
-	if mayRetry && !c.connectionGood {
-		fmt.Println("returning ErrBadConn!")
-		return driver.ErrBadConn
+	if !c.connectionGood {
+		return Error{
+			Message: err.Error(),
+			badConn: mayRetry,
+		}
 	}
 	return err
 }

--- a/mssql.go
+++ b/mssql.go
@@ -200,7 +200,7 @@ func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 	}
 
 	switch err.(type) {
-	case serverError, net.Error, StreamError:
+	case ServerError, net.Error, StreamError:
 		c.connectionGood = false
 	}
 

--- a/mssql.go
+++ b/mssql.go
@@ -207,11 +207,11 @@ func (c *Conn) checkBadConn(err error, mayRetry bool) error {
 		c.connectionGood = false
 		err.sqlError.badConn = mayRetry
 		return err
-	case net.Error, StreamError:
-		c.connectionGood = false
 	case Error:
 		err.badConn = mayRetry && !c.connectionGood
 		return err
+	case net.Error, StreamError:
+		c.connectionGood = false
 	}
 
 	if !c.connectionGood {

--- a/mssql.go
+++ b/mssql.go
@@ -182,7 +182,7 @@ func (c *Conn) IsValid() bool {
 }
 
 // checkBadConn marks the connection as bad based on the characteristics
-// of the suplied error. Bad connections will be dropped from the connection
+// of the supplied error. Bad connections will be dropped from the connection
 // pool rather than reused.
 //
 // If bad connection retry is enabled and the error + connection state permits

--- a/mssql_go118.go
+++ b/mssql_go118.go
@@ -1,0 +1,14 @@
+// +build go1.18
+
+package mssql
+
+// newRetryableError returns an error that allows the database/sql package
+// to automatically retry the failed query. Versions of Go 1.18 and higher
+// use errors.Is to determine whether or not a failed query can be retried.
+// Therefore, we wrap the underlying error in a RetryableError that both
+// implements errors.Is for automatic retry and maintains the error details.
+func newRetryableError(err error) error {
+	return RetryableError{
+		err: err,
+	}
+}

--- a/mssql_go118pre.go
+++ b/mssql_go118pre.go
@@ -1,0 +1,17 @@
+// +build !go1.18
+
+package mssql
+
+import (
+	"database/sql/driver"
+)
+
+// newRetryableError returns an error that allows the database/sql package
+// to automatically retry the failed query. Versions of Go lower than 1.18
+// compare directly to the sentinel error driver.ErrBadConn to determine
+// whether or not a failed query can be retried. Therefore, we replace the
+// actual error with driver.ErrBadConn, enabling retry but losing the error
+// details.
+func newRetryableError(err error) error {
+	return driver.ErrBadConn
+}

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -3,7 +3,14 @@ package mssql
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
 	"testing"
+
+	"github.com/denisenkom/go-mssqldb/msdsn"
 )
 
 func TestBadOpen(t *testing.T) {
@@ -68,4 +75,81 @@ func TestConvertIsolationLevel(t *testing.T) {
 	if err == nil {
 		t.Fatal("must fail but it didn't")
 	}
+}
+
+// equalErrors is a helper function that compares two errors
+// by comparing their nilness, underlying type, and Error messages
+func equalErrors(e1 error, e2 error) bool {
+	if e1 == nil && e2 == nil {
+		return true
+	}
+	if e1 == nil && e2 != nil || e1 != nil && e2 == nil {
+		return false
+	}
+	return reflect.TypeOf(e1) == reflect.TypeOf(e2) &&
+		e1.Error() == e2.Error()
+}
+
+// TestCheckBadConn verifies that different combinations of
+// configuration, inputs and errors result in the proper output
+// error and connection state.
+func TestCheckBadConn(t *testing.T) {
+
+	netErr := &net.OpError{Err: fmt.Errorf("fake net.Error")}
+	streamErr := StreamError{Message: "fake StreamError"}
+	serverErr := ServerError{sqlError: Error{Message: "fake ServerError"}}
+	goodConnErr := fmt.Errorf("fake error that leaves connection good")
+
+	testInputs := []struct {
+		err              error
+		mayRetry         bool
+		disableRetry     bool
+		expectedErr      error
+		expectedConnGood bool
+	}{
+		{nil, false, false, nil, true},
+		{nil, true, false, nil, true},
+		{nil, false, true, nil, true},
+		{nil, true, true, nil, true},
+		{io.EOF, false, false, io.EOF, false},
+		{io.EOF, true, false, newRetryableError(io.EOF), false},
+		{io.EOF, false, true, io.EOF, false},
+		{io.EOF, true, true, io.EOF, false},
+		{netErr, false, false, netErr, false},
+		{netErr, true, false, newRetryableError(netErr), false},
+		{netErr, false, true, netErr, false},
+		{netErr, true, true, netErr, false},
+		{streamErr, false, false, streamErr, false},
+		{streamErr, true, false, newRetryableError(streamErr), false},
+		{streamErr, false, true, streamErr, false},
+		{streamErr, true, true, streamErr, false},
+		{serverErr, false, false, serverErr, false},
+		{serverErr, true, false, newRetryableError(serverErr), false},
+		{serverErr, false, true, serverErr, false},
+		{serverErr, true, true, serverErr, false},
+		{goodConnErr, false, false, goodConnErr, true},
+		{goodConnErr, true, false, goodConnErr, true},
+		{goodConnErr, false, true, goodConnErr, true},
+		{goodConnErr, true, true, goodConnErr, true},
+	}
+
+	c := Conn{connector: &Connector{params: msdsn.Config{}}}
+
+	for _, ti := range testInputs {
+		c.connectionGood = true
+		c.connector.params.DisableRetry = ti.disableRetry
+		actualErr := c.checkBadConn(ti.err, ti.mayRetry)
+		if !equalErrors(actualErr, ti.expectedErr) ||
+			c.connectionGood != ti.expectedConnGood {
+			t.Fatalf("checkBadConn returned unexpected result for input err = '%+v', mayRetry = '%t', disableRetry = '%t': "+
+				"Got output err = '%+v', connectionGood = '%t', "+
+				"wanted output err = '%+v', connectionGood = '%t'",
+				ti.err, ti.mayRetry, ti.disableRetry, actualErr, c.connectionGood, ti.expectedErr, ti.expectedConnGood)
+		}
+	}
+
+	// This must be the final test in this function, because we expect it to panic
+	defer func() { recover() }()
+	c.checkBadConn(driver.ErrBadConn, true)
+	t.Fatalf("checkBadConn did not panic as expected when passed driverErrBadConn")
 }

--- a/queries_test.go
+++ b/queries_test.go
@@ -2486,6 +2486,16 @@ func TestDisconnect5(t *testing.T) {
 	_, isServerError := err.(ServerError)
 	_, isNetError := err.(*net.OpError)
 	if !isServerError && !isNetError {
+		// There are a variety of errors that could be returned for a broken
+		// connection. The majority should fall within the mssql.ServerError
+		// and net.OpError categories. We try to make our test more specific
+		// by accepting only those errors, but that makes this test somewhat
+		// less resilient than desired. If this test fails because we start
+		// seeing previously unseen errors and those new errors also indicate
+		// a broken connection, then add them above. If this happens regularly,
+		// consider just allowing any error here. That will reduce any false
+		// alarms from this test at the cost of reduced ability to detect
+		// genuine test failure.
 		t.Fatalf("Failed to break connection. Got err = '%#v', wanted error = '%s'",
 			err, "mssql.ServerError or net.OpError")
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -2295,10 +2295,11 @@ func TestDisconnect3(t *testing.T) {
 	// Disable retry to provide behavior requested in #275
 	cp := testConnParams(t)
 	cp.DisableRetry = true
+	connStr := cp.URL().String()
 
 	// Open a connection pool that holds a single connection to make sure all
 	// queries run on the same connection.
-	db, err := sql.Open("sqlserver", cp.URL().String())
+	db, err := sql.Open("sqlserver", connStr)
 	if err != nil {
 		t.Log(err)
 	}
@@ -2361,10 +2362,11 @@ func TestDisconnect4(t *testing.T) {
 	// Enable retry to provide behavior requested in #586
 	cp := testConnParams(t)
 	cp.DisableRetry = false
+	connStr := cp.URL().String()
 
 	// Open a connection pool that holds a single connection to make sure all
 	// queries run on the same connection.
-	db, err := sql.Open("sqlserver", makeConnStr(t).String())
+	db, err := sql.Open("sqlserver", connStr)
 	if err != nil {
 		t.Log(err)
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -2263,6 +2264,190 @@ func TestDisconnect2(t *testing.T) {
 		}
 	case <-timeout:
 		t.Fatal("timeout")
+	}
+}
+
+// TestDisconnect3 verifies the bad connection behavior defined in
+// response to issue #275. In this mode a query that starts on a bad
+// connection should always fail immediately, returning a detailed
+// error message.
+func TestDisconnect3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short")
+	}
+	checkConnStr(t)
+	SetLogger(testLogger{t})
+
+	// Revert to the normal dialer after the test is done.
+	normalCreateDialer := createDialer
+	defer func() {
+		createDialer = normalCreateDialer
+	}()
+
+	// Create a dialer we can interrupt to simulate a broken connection
+	var di *dialerInterrupt
+	createDialer = func(p *msdsn.Config) Dialer {
+		nd := netDialer{&net.Dialer{Timeout: p.DialTimeout, KeepAlive: p.KeepAlive}}
+		di = &dialerInterrupt{nd: nd}
+		return di
+	}
+
+	// Disable retry to provide behavior requested in #275
+	cp := testConnParams(t)
+	cp.DisableRetry = true
+
+	// Open a connection pool that holds a single connection to make sure all
+	// queries run on the same connection.
+	db, err := sql.Open("sqlserver", cp.URL().String())
+	if err != nil {
+		t.Log(err)
+	}
+	defer db.Close()
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
+
+	// Demonstrate connection is good the first time we use it
+	result := "<none>"
+	desiredResult := "before disconnect"
+	row := db.QueryRow(fmt.Sprintf("select '%s'", desiredResult))
+	if err = row.Scan(&result); err != nil || result != desiredResult {
+		t.Fatalf("Connection bad on first use. "+
+			"Got result = '%s', err = '%v', wanted result = '%s', err = '%v'",
+			result, err, desiredResult, nil)
+	}
+
+	// Simulate breaking the connection
+	di.Interrupt(true)
+	di.Interrupt(false)
+
+	// Broken connection should cause immediate and final failure
+	result = "<none>"
+	desiredErr := "failed to send SQL Batch: disconnect"
+	row = db.QueryRow("select 'after disconnect'")
+	if err = row.Scan(&result); err == nil || err.Error() != desiredErr {
+		t.Fatalf("Connection did not fail as expected. "+
+			"Got result = '%s', err = '%v', wanted result = '%s', err = '%v'",
+			result, err, "<none>", desiredErr)
+	}
+}
+
+// TestDisconnect4 verifies the bad connection behavior defined in
+// response to issue #586. In this mode a query that starts on a bad
+// connection should fail with an error that allows the automatic retry
+// logic within database/sql to retry the query with a new connection,
+// which then succeeds. From the perspective of the consuming application,
+// there is no error.
+func TestDisconnect4(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short")
+	}
+	checkConnStr(t)
+	SetLogger(testLogger{t})
+
+	// Revert to the normal dialer after the test is done.
+	normalCreateDialer := createDialer
+	defer func() {
+		createDialer = normalCreateDialer
+	}()
+
+	// Create a dialer we can interrupt to simulate a broken connection
+	var di *dialerInterrupt
+	createDialer = func(p *msdsn.Config) Dialer {
+		nd := netDialer{&net.Dialer{Timeout: p.DialTimeout, KeepAlive: p.KeepAlive}}
+		di = &dialerInterrupt{nd: nd}
+		return di
+	}
+
+	// Enable retry to provide behavior requested in #586
+	cp := testConnParams(t)
+	cp.DisableRetry = false
+
+	// Open a connection pool that holds a single connection to make sure all
+	// queries run on the same connection.
+	db, err := sql.Open("sqlserver", makeConnStr(t).String())
+	if err != nil {
+		t.Log(err)
+	}
+	defer db.Close()
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
+
+	// Demonstrate connection is good the first time we use it
+	result := "<none>"
+	desiredResult := "before disconnect"
+	row := db.QueryRow(fmt.Sprintf("select '%s'", desiredResult))
+	if err = row.Scan(&result); err != nil || result != desiredResult {
+		t.Fatalf("Connection bad on first use. "+
+			"Got result = '%s', err = '%v', wanted result = '%s', err = '%v'",
+			result, err, desiredResult, nil)
+	}
+
+	// Break the connection
+	di.Interrupt(true)
+	di.Interrupt(false)
+
+	// Broken connection should cause the next query to initially fail internally,
+	// but then the logic within database/sql should transparently discard the bad
+	// connection, retry the query with a new connection, and ultimately succeed.
+	result = "<none>"
+	desiredResult = "after disconnect"
+	row = db.QueryRow(fmt.Sprintf("select '%s'", desiredResult))
+	if err = row.Scan(&result); err != nil || result != desiredResult {
+		t.Fatalf("Connection bad on second use. "+
+			"Got result = '%s', err = '%v', wanted result = '%s', err = '%v'",
+			result, err, desiredResult, nil)
+	}
+}
+
+// TestDisconnect5 verifies that a connection that goes bad during a query results in:
+// 1. The query failing with a detailed error message
+// 2. The bad connection being immediately removed from the pool
+// 3. The subsequent query using a new connection and succeeding
+func TestDisconnect5(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short")
+	}
+	checkConnStr(t)
+	SetLogger(testLogger{t})
+
+	// Open a connection pool that holds a single connection to make sure all
+	// queries run on the same connection.
+	db, err := sql.Open("sqlserver", makeConnStr(t).String())
+	if err != nil {
+		t.Log(err)
+	}
+	defer db.Close()
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
+
+	// Demonstrate connection is good the first time we use it
+	result := "<none>"
+	desiredResult := "before disconnect"
+	row := db.QueryRow(fmt.Sprintf("select '%s'", desiredResult))
+	if err = row.Scan(&result); err != nil || result != desiredResult {
+		t.Fatalf("Connection bad on first use. "+
+			"Got result = '%s', err = '%v', wanted result = '%s', err = '%v'",
+			result, err, desiredResult, nil)
+	}
+
+	// Break the connection during a query by raising a fatal error in SQL Server
+	_, err = db.Exec("raiserror('fatal error', 20, 1) with log")
+	var sqlErr Error
+	if !errors.As(err, &sqlErr) || sqlErr.Number != 596 {
+		t.Fatalf("Failed to break connection. Got err = '%v', wanted error = '%v'",
+			err, "Cannot continue the execution because the session is in the kill state.")
+	}
+
+	// The broken connection should have been removed from the pool and replaced
+	// with a new connection at the end of the previous query, allowing this next
+	// query to succeed.
+	result = "<none>"
+	desiredResult = "after disconnect"
+	row = db.QueryRow(fmt.Sprintf("select '%s'", desiredResult))
+	if err = row.Scan(&result); err != nil || result != desiredResult {
+		t.Fatalf("Connection bad on second use. "+
+			"Got result = '%s', err = '%v', wanted result = '%s', err = '%v'",
+			result, err, desiredResult, nil)
 	}
 }
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2332,7 +2332,7 @@ func TestDisconnect3(t *testing.T) {
 	row := db.QueryRow(fmt.Sprintf("select '%s'", desiredResult))
 	if err = row.Scan(&result); err != nil || result != desiredResult {
 		t.Fatalf("Connection bad on first use. "+
-			"Got result = '%s', err = '%v', wanted result = '%s', err = '%v'",
+			"Got result = '%s', err = '%v',  result = '%s', err = '%v'",
 			result, err, desiredResult, nil)
 	}
 

--- a/token.go
+++ b/token.go
@@ -75,6 +75,15 @@ const (
 	fedAuthInfoSPN    = 0x02
 )
 
+// serverError is returned when we receive a DONE token with DONE_SRVERROR flag.
+// It means an error was severe enough to require the result set to be discarded.
+// It was observed when raising fatal errors, with severity 20 or above.
+// These errors also close the connection.
+//
+// https://docs.microsoft.com/en-us/openspecs/sql_server_protocols/ms-sstds/bd77f9d0-6929-4fe1-b163-a525cd7cabd4
+// https://docs.microsoft.com/en-us/openspecs/sql_server_protocols/ms-sstds/90fb176f-83c6-4c9c-bc04-aaa8a400a5a1
+var serverError = errors.New("SQL Server had internal error")
+
 // COLMETADATA flags
 // https://msdn.microsoft.com/en-us/library/dd357363.aspx
 const (
@@ -699,7 +708,7 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[strin
 				sess.log.Printf("got DONE or DONEPROC status=%d", done.Status)
 			}
 			if done.Status&doneSrvError != 0 {
-				ch <- errors.New("SQL Server had internal error")
+				ch <- serverError
 				return
 			}
 			if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {

--- a/token.go
+++ b/token.go
@@ -82,7 +82,17 @@ const (
 //
 // https://docs.microsoft.com/en-us/openspecs/sql_server_protocols/ms-sstds/bd77f9d0-6929-4fe1-b163-a525cd7cabd4
 // https://docs.microsoft.com/en-us/openspecs/sql_server_protocols/ms-sstds/90fb176f-83c6-4c9c-bc04-aaa8a400a5a1
-var serverError = errors.New("SQL Server had internal error")
+type serverError struct {
+	sqlError Error
+}
+
+func (e serverError) Error() string {
+	return "SQL Server had internal error"
+}
+
+func (e serverError) Unwrap() error {
+	return e.sqlError
+}
 
 // COLMETADATA flags
 // https://msdn.microsoft.com/en-us/library/dd357363.aspx
@@ -708,7 +718,7 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[strin
 				sess.log.Printf("got DONE or DONEPROC status=%d", done.Status)
 			}
 			if done.Status&doneSrvError != 0 {
-				ch <- serverError
+				ch <- serverError{done.getError()}
 				return
 			}
 			if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {


### PR DESCRIPTION
This pull request resolves #586. It is the result of collaboration by @kardianos, @tc-hib, @shueybubbles, and myself.

First, it adds an optional parameter named "disableretry" to the connection string. When set to "true", this parameter configures go-mssqldb's retry policy to match that requested in issue #275: failed queries immediately return a detailed error.  When set to "false", this parameter configures the retry policy to match that requested in issue #586: failed queries are automatically retried as per the standard library's database/sql retry logic.

For versions of Go less than 1.18, the default value for "disableretry" is "true", maintaining backwards compatibility.

Second, starting with Go 1.18 when (we hope) kardianos' change proposal [333949 ](https://go-review.googlesource.com/c/go/+/333949) is accepted, this pull request wraps errors on bad connections with a new RetryableError error that allows both automatic retry and detailed errors, satisfying both issue #275 and #586. At that time the default value for "disableretry" will change to "false".

The change is designed to be mostly backwards compatible. Prior to Go 1.18 the default behavior will be identical to current behavior with the exception that additional information will be returned for server errors.

Subsequent to Go 1.18 it will be identical in spirit to current behavior, but not 100% the same. Automatic retries that are transparent to the caller will be allowed, and when all retries fail, the returned errors will show the same Error() messages as now but will have to be unwrapped for anyone who is comparing errors directly. I think this is a reasonable compromise to restore standard Go retry behavior to go-msqldb.

I have tested on both Go 1.16.5 and a mock of Go 1.18 built from kardianos change proposal [333949 ](https://go-review.googlesource.com/c/go/+/333949).

I still have some questions and don't expect that this pull request will be accepted as is, but I wanted to open it now to facilitate discussion of it. Some open questions are:

1. Is Go 1.18 the right time to change the default retry behavior, or should that be done now (a more breaking change)?
2. Are we comfortable with building in now a dependency on Go 1.18 for something that, while it ought to be included by all rights, isn't yet guaranteed to be included in 1.18?