### PR TITLE
Don't send attention during login

### DIFF
--- a/queries_test.go
+++ b/queries_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1982,7 +1981,7 @@ func getLatency(t *testing.T) (latency time.Duration, increment time.Duration) {
 		port = "1433"
 	}
 	for latency < 2000*time.Millisecond {
-		t.Logf("Dialing host %s with timeout %v", host, latency.Milliseconds())
+		t.Logf("Dialing host %s with timeout %s", host, latency)
 		_, err := net.DialTimeout("tcp", host+":"+port, latency)
 		if err == nil {
 			return latency, increment
@@ -2035,7 +2034,7 @@ func TestLoginTimeout(t *testing.T) {
 		if !oe.Timeout() {
 			t.Fatalf("Got non-timeout error %s", oe.Error())
 		}
-	} else if !errors.Is(err, context.DeadlineExceeded) {
+	} else if err != context.DeadlineExceeded {
 		t.Fatalf("wrong kind of error for login or query timeout: %+v", err)
 	}
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2007,7 +2007,7 @@ func TestQueryTimeout(t *testing.T) {
 	defer cancel()
 	_, err := conn.ExecContext(ctx, "waitfor delay '00:00:20'")
 	if err != context.DeadlineExceeded {
-		t.Errorf("ExecContext expected to fail with DeadlineExceeded or os.ErrDeadlineExceeded but it returned %v", err)
+		t.Errorf("ExecContext expected to fail with DeadlineExceeded but it returned %v", err)
 	}
 
 	// connection should be usable after timeout

--- a/tds.go
+++ b/tds.go
@@ -1190,6 +1190,8 @@ initiate_connection:
 	// packet exchanges to complete the login sequence.
 	for loginAck := false; !loginAck; {
 		reader := startReading(&sess, ctx, outputs{})
+		// don't send attention or wait for cancel confirmation during login
+		reader.noAttn = true
 
 		for {
 			tok, err := reader.nextToken()

--- a/tds_test.go
+++ b/tds_test.go
@@ -221,7 +221,7 @@ func testConnParams(t testing.TB) msdsn.Config {
 	if err == nil {
 		rdr := bufio.NewReader(f)
 		dsn, err := rdr.ReadString('\n')
-		if err != io.EOF {
+		if err != io.EOF && err != nil {
 			t.Fatal(err)
 		}
 		params, _, err := msdsn.Parse(dsn)


### PR DESCRIPTION
I saw test failures per issue #679 due to higher latency connections to my servers. The error should have been `DeadlineExceeded` but it was getting a spurious `did not get cancellation confirmation`.

The fix is to instruct the reader not to send attention during `ctx->done()` handling during the login processing.
Along the way I fixed the set language test that was failing on my server, which has a case sensitive collation. 