### PR TITLE
Context Logger

### DIFF
--- a/bad_server_test.go
+++ b/bad_server_test.go
@@ -42,7 +42,9 @@ func testBadServer(t *testing.T, handler func(net.Conn)) {
 		handler(conn)
 		_ = conn.Close()
 	}()
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 	testConnectionBad(t, fmt.Sprintf("host=%s;port=%d;log=255", addr.IP.String(), addr.Port))
 }
 

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -238,7 +238,7 @@ func (b *Bulk) Done() (rowcount int64, err error) {
 	reader := startReading(b.cn.sess, b.ctx, outputs{})
 	err = reader.iterateResponse()
 	if err != nil {
-		return 0, b.cn.checkBadConn(err, false)
+		return 0, b.cn.checkBadConn(b.ctx, err, false)
 	}
 
 	return reader.rowCount, nil

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/denisenkom/go-mssqldb/internal/decimal"
+	"github.com/denisenkom/go-mssqldb/msdsn"
 )
 
 type Bulk struct {
@@ -86,7 +87,7 @@ func (b *Bulk) sendBulkCommand(ctx context.Context) (err error) {
 				bulkCol.ti.TypeId = typeBigVarBin
 			}
 			b.bulkColumns = append(b.bulkColumns, *bulkCol)
-			b.dlogf("Adding column %s %s %#x", colname, bulkCol.ColName, bulkCol.ti.TypeId)
+			b.dlogf(ctx, "Adding column %s %s %#x", colname, bulkCol.ColName, bulkCol.ti.TypeId)
 		} else {
 			return fmt.Errorf("column %s does not exist in destination table %s", colname, b.tablename)
 		}
@@ -138,7 +139,7 @@ func (b *Bulk) sendBulkCommand(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("Prepare failed: %s", err.Error())
 	}
-	b.dlogf(query)
+	b.dlogf(ctx, query)
 
 	_, err = stmt.(*Stmt).ExecContext(ctx, nil)
 	if err != nil {
@@ -211,7 +212,7 @@ func (b *Bulk) makeRowData(row []interface{}) ([]byte, error) {
 		}
 	}
 
-	b.dlogf("row[%d] %s\n", b.numRows, logcol.String())
+	b.dlogf(b.ctx, "row[%d] %s", b.numRows, logcol.String())
 
 	return buf.Bytes(), nil
 }
@@ -300,7 +301,7 @@ func (b *Bulk) getMetadata(ctx context.Context) (err error) {
 
 	if b.Debug {
 		for _, col := range b.metadata {
-			b.dlogf("col: %s typeId: %#x size: %d scale: %d prec: %d flags: %d lcid: %#x\n",
+			b.dlogf(ctx, "col: %s typeId: %#x size: %d scale: %d prec: %d flags: %d lcid: %#x",
 				col.ColName, col.ti.TypeId, col.ti.Size, col.ti.Scale, col.ti.Prec,
 				col.Flags, col.ti.Collation.LcidAndFlags)
 		}
@@ -590,8 +591,8 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 
 }
 
-func (b *Bulk) dlogf(format string, v ...interface{}) {
+func (b *Bulk) dlogf(ctx context.Context, format string, v ...interface{}) {
 	if b.Debug {
-		b.cn.sess.log.Printf(format, v...)
+		b.cn.sess.log.Log(ctx, msdsn.LogDebug, fmt.Sprintf(format, v...))
 	}
 }

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -593,6 +593,6 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 
 func (b *Bulk) dlogf(ctx context.Context, format string, v ...interface{}) {
 	if b.Debug {
-		b.cn.sess.log.Log(ctx, msdsn.LogDebug, fmt.Sprintf(format, v...))
+		b.cn.sess.logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf(format, v...))
 	}
 }

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -94,8 +94,9 @@ func TestBulkcopy(t *testing.T) {
 		values[i] = val.in
 	}
 
-	pool := open(t)
+	pool, logger := open(t)
 	defer pool.Close()
+	defer logger.StopLogging()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/log.go
+++ b/log.go
@@ -16,34 +16,46 @@ const (
 	logDebug       = uint64(msdsn.LogDebug)
 )
 
+// Logger is an interface you can implement to have the go-msqldb
+// driver automatically log detailed information on your behalf
 type Logger interface {
 	Printf(format string, v ...interface{})
 	Println(v ...interface{})
 }
 
+// ContextLogger is an interface that provides more information
+// than Logger and lets you log messages yourself. This gives you
+// more information to log (e.g. trace IDs in the context), more
+// control over the logging activity (e.g. log it, trace it, or
+// log and trace it, depending on the class of message), and lets
+// you log in exactly the format you want.
 type ContextLogger interface {
 	Log(ctx context.Context, category msdsn.Log, msg string)
 }
 
-// optionalCtxLogger implements the ContextLogger interface with
+// optionalLogger implements the ContextLogger interface with
 // a default "do nothing" behavior that can be overridden by an
 // optional ContextLogger supplied by the user.
-type optionalCtxLogger struct {
-	ctxLogger ContextLogger
+type optionalLogger struct {
+	logger ContextLogger
 }
 
 // Log does nothing unless the user has specified an optional
 // ContextLogger to override the "do nothing" default behavior.
-func (o optionalCtxLogger) Log(ctx context.Context, category msdsn.Log, msg string) {
-	if nil != o.ctxLogger {
-		o.ctxLogger.Log(ctx, category, msg)
+func (o optionalLogger) Log(ctx context.Context, category msdsn.Log, msg string) {
+	if nil != o.logger {
+		o.logger.Log(ctx, category, msg)
 	}
 }
 
+// loggerAdapter converts Logger interfaces into ContextLogger
+// interfaces. It provides backwards compatibility.
 type loggerAdapter struct {
 	logger Logger
 }
 
+// Log passes the message to the underlying Logger interface's
+// Println function, emulating the orignal Logger behavior.
 func (la loggerAdapter) Log(_ context.Context, _ msdsn.Log, msg string) {
 	la.logger.Println(msg)
 }

--- a/log.go
+++ b/log.go
@@ -14,6 +14,7 @@ const (
 	logParams      = uint64(msdsn.LogParams)
 	logTransaction = uint64(msdsn.LogTransaction)
 	logDebug       = uint64(msdsn.LogDebug)
+	logRetries     = uint64(msdsn.LogRetries)
 )
 
 // Logger is an interface you can implement to have the go-msqldb

--- a/log.go
+++ b/log.go
@@ -1,7 +1,19 @@
 package mssql
 
 import (
-	"log"
+	"context"
+
+	"github.com/denisenkom/go-mssqldb/msdsn"
+)
+
+const (
+	logErrors      = uint64(msdsn.LogErrors)
+	logMessages    = uint64(msdsn.LogMessages)
+	logRows        = uint64(msdsn.LogRows)
+	logSQL         = uint64(msdsn.LogSQL)
+	logParams      = uint64(msdsn.LogParams)
+	logTransaction = uint64(msdsn.LogTransaction)
+	logDebug       = uint64(msdsn.LogDebug)
 )
 
 type Logger interface {
@@ -9,22 +21,29 @@ type Logger interface {
 	Println(v ...interface{})
 }
 
-type optionalLogger struct {
+type ContextLogger interface {
+	Log(ctx context.Context, category msdsn.Log, msg string)
+}
+
+// optionalCtxLogger implements the ContextLogger interface with
+// a default "do nothing" behavior that can be overridden by an
+// optional ContextLogger supplied by the user.
+type optionalCtxLogger struct {
+	ctxLogger ContextLogger
+}
+
+// Log does nothing unless the user has specified an optional
+// ContextLogger to override the "do nothing" default behavior.
+func (o optionalCtxLogger) Log(ctx context.Context, category msdsn.Log, msg string) {
+	if nil != o.ctxLogger {
+		o.ctxLogger.Log(ctx, category, msg)
+	}
+}
+
+type loggerAdapter struct {
 	logger Logger
 }
 
-func (o optionalLogger) Printf(format string, v ...interface{}) {
-	if o.logger != nil {
-		o.logger.Printf(format, v...)
-	} else {
-		log.Printf(format, v...)
-	}
-}
-
-func (o optionalLogger) Println(v ...interface{}) {
-	if o.logger != nil {
-		o.logger.Println(v...)
-	} else {
-		log.Println(v...)
-	}
+func (la loggerAdapter) Log(_ context.Context, _ msdsn.Log, msg string) {
+	la.logger.Println(msg)
 }

--- a/log.go
+++ b/log.go
@@ -57,6 +57,15 @@ type loggerAdapter struct {
 
 // Log passes the message to the underlying Logger interface's
 // Println function, emulating the orignal Logger behavior.
-func (la loggerAdapter) Log(_ context.Context, _ msdsn.Log, msg string) {
+func (la loggerAdapter) Log(_ context.Context, category msdsn.Log, msg string) {
+
+	// Add prefix for certain categories
+	switch category {
+	case msdsn.LogErrors:
+		msg = "ERROR: " + msg
+	case msdsn.LogRetries:
+		msg = "RETRY: " + msg
+	}
+
 	la.logger.Println(msg)
 }

--- a/log_go113_test.go
+++ b/log_go113_test.go
@@ -1,0 +1,12 @@
+// +build go1.13
+
+package mssql
+
+import (
+	"io"
+	"log"
+)
+
+func currentLogWriter() io.Writer {
+	return log.Writer()
+}

--- a/log_go113pre_test.go
+++ b/log_go113pre_test.go
@@ -1,0 +1,14 @@
+// +build !go1.13
+
+package mssql
+
+import (
+	"io"
+	"os"
+)
+
+func currentLogWriter() io.Writer {
+	// There is no function for getting the current writer in versions of
+	// Go older than 1.13, so we just return the default writer.
+	return os.Stderr
+}

--- a/log_test.go
+++ b/log_test.go
@@ -39,7 +39,7 @@ func (l bufContextLogger) Log(_ context.Context, _ msdsn.Log, msg string) {
 func TestLogger(t *testing.T) {
 
 	// Record system log settings and restore them after the test
-	originalWriter := log.Writer()
+	originalWriter := currentLogWriter()
 	originalFlags := log.Flags()
 	defer func() {
 		log.SetOutput(originalWriter)

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,177 @@
+package mssql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/denisenkom/go-mssqldb/msdsn"
+)
+
+// bufLogger implements the Logger interface for testing purposes.
+// It captures the log messages in a buffer for comparison
+type bufLogger struct {
+	Buff *bytes.Buffer
+}
+
+func (l bufLogger) Printf(format string, v ...interface{}) {
+	l.Buff.WriteString(fmt.Sprintf(format, v...))
+}
+
+func (l bufLogger) Println(v ...interface{}) {
+	l.Buff.WriteString(fmt.Sprintln(v...))
+}
+
+// bufContextLogger implements the ContextLogger interface for testing purposes.
+// It captures the log messages in a buffer for comparison
+type bufContextLogger struct {
+	Buff *bytes.Buffer
+}
+
+func (l bufContextLogger) Log(ctx context.Context, logLevel msdsn.Log, msg string) {
+	l.Buff.WriteString(msg)
+}
+
+// TestLogger tests the various options for logging
+func TestLogger(t *testing.T) {
+
+	// Record system log settings and restore them after the test
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	defer func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+	}()
+
+	// Set system log's writer so that we can capture the log output
+	// in a buffer for comparison with expected test results
+	var sysLogBuf bytes.Buffer
+	log.SetOutput(&sysLogBuf)
+	log.SetFlags(0)
+
+	// Record existing go-mssqldb loggers and restore them after the test
+	originalLogger := driverInstance.logger
+	originaLoggerNoProcess := driverInstanceNoProcess.logger
+	defer func() {
+		driverInstance.SetContextLogger(originalLogger)
+		driverInstanceNoProcess.SetContextLogger(originaLoggerNoProcess)
+	}()
+
+	// Buffer for capturing messages logged to our Logger/ContextLogger implementations
+	var captureBuf bytes.Buffer
+
+	// Set up a retryable error and the test cases that will exercise it
+	errMsg := "Retryable Test Error"
+	inErr := StreamError{Message: errMsg}
+
+	testcases := [...]struct {
+		name        string
+		driver      *Driver
+		logger      Logger        // only one of logger or ctxLogger should be set per test
+		ctxLogger   ContextLogger // only one of logger or ctxLogger should be set per test
+		expectedMsg string
+	}{
+		{
+			name:        "mssql with no logging",
+			driver:      driverInstance,
+			logger:      nil,
+			ctxLogger:   nil,
+			expectedMsg: "",
+		},
+		{
+			name:        "sqlserver with no logging",
+			driver:      driverInstanceNoProcess,
+			logger:      nil,
+			ctxLogger:   nil,
+			expectedMsg: "",
+		},
+		{
+			name:        "mssql with Logger logging",
+			driver:      driverInstance,
+			logger:      bufLogger{&captureBuf},
+			ctxLogger:   nil,
+			expectedMsg: errMsg,
+		},
+		{
+			name:        "sqlserver with Logger logging",
+			driver:      driverInstanceNoProcess,
+			logger:      bufLogger{&captureBuf},
+			ctxLogger:   nil,
+			expectedMsg: errMsg,
+		},
+		{
+			name:        "mssql with ContextLogger logging",
+			driver:      driverInstance,
+			logger:      nil,
+			ctxLogger:   bufContextLogger{&captureBuf},
+			expectedMsg: errMsg,
+		},
+		{
+			name:        "sqlserver with ContextLogger logging",
+			driver:      driverInstanceNoProcess,
+			logger:      nil,
+			ctxLogger:   bufContextLogger{&captureBuf},
+			expectedMsg: errMsg,
+		},
+	}
+
+	for _, tc := range testcases {
+
+		sysLogBuf.Reset()
+		captureBuf.Reset()
+
+		// Set the logger
+		if tc.logger != nil {
+			SetLogger(tc.logger)
+		} else if tc.ctxLogger != nil {
+			SetContextLogger(tc.ctxLogger)
+		} else {
+			SetContextLogger(nil)
+		}
+
+		// Set up a mock connection for the test. Normally these values
+		// would be set in the mssql.connect function, but that function
+		// doesn't provide a ready mechanism for mocking the connection,
+		// so we set the fields directly here.
+		c := Conn{
+			connector: &Connector{
+				params: msdsn.Config{
+					DisableRetry: false,
+				},
+			},
+			sess: &tdsSession{
+				logger: tc.driver.logger,
+			},
+			connectionGood: true,
+		}
+
+		// Induce a retry
+		outErr := c.checkBadConn(context.Background(), inErr, true)
+
+		// Ensure that we exercised the retryable error path
+		if outErr != newRetryableError(inErr) {
+			t.Fatalf("checkBadConn did not return retryable error for driver '%s'. Expected '%+v', Got '%+v'",
+				tc.name, newRetryableError(inErr), outErr)
+		}
+
+		// Ensure that we did not log to the system log
+		if sysLogBuf.Len() > 0 {
+			t.Fatalf("Unexpected data logged to system log for driver '%s'. Expected 0 bytes written, got %d bytes written: '%s'",
+				tc.name, sysLogBuf.Len(), strings.TrimRight(sysLogBuf.String(), "\n"))
+		}
+
+		// Ensure that the expected message was logged to whaterver logger we configured
+		loggedMsg := ""
+		if tc.logger != nil || tc.ctxLogger != nil {
+			loggedMsg = strings.TrimRight(captureBuf.String(), "\n")
+		}
+
+		if tc.expectedMsg != loggedMsg {
+			t.Fatalf("Unexpected data logged for test case '%s'. Expected '%s', got: '%s'",
+				tc.name, tc.expectedMsg, loggedMsg)
+		}
+	}
+}

--- a/log_test.go
+++ b/log_test.go
@@ -31,7 +31,7 @@ type bufContextLogger struct {
 	Buff *bytes.Buffer
 }
 
-func (l bufContextLogger) Log(ctx context.Context, logLevel msdsn.Log, msg string) {
+func (l bufContextLogger) Log(_ context.Context, _ msdsn.Log, msg string) {
 	l.Buff.WriteString(msg)
 }
 
@@ -65,6 +65,7 @@ func TestLogger(t *testing.T) {
 
 	// Set up a retryable error and the test cases that will exercise it
 	errMsg := "Retryable Test Error"
+	retryPrefix := "RETRY: "
 	inErr := StreamError{Message: errMsg}
 
 	testcases := [...]struct {
@@ -97,7 +98,7 @@ func TestLogger(t *testing.T) {
 			logger:      bufLogger{&captureBuf},
 			ctxLogger:   nil,
 			flags:       msdsn.LogRetries,
-			expectedMsg: errMsg,
+			expectedMsg: retryPrefix + errMsg,
 		},
 		{
 			name:        "sqlserver with Logger logging",
@@ -105,7 +106,7 @@ func TestLogger(t *testing.T) {
 			logger:      bufLogger{&captureBuf},
 			ctxLogger:   nil,
 			flags:       msdsn.LogRetries,
-			expectedMsg: errMsg,
+			expectedMsg: retryPrefix + errMsg,
 		},
 		{
 			name:        "mssql with ContextLogger logging",

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -33,6 +33,7 @@ const (
 	LogParams      Log = 16
 	LogTransaction Log = 32
 	LogDebug       Log = 64
+	LogRetries     Log = 128
 )
 
 type Config struct {

--- a/mssql_perf_test.go
+++ b/mssql_perf_test.go
@@ -210,6 +210,6 @@ func BenchmarkSelectParser(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		processSingleResponse(sess, ch, outputs{})
+		processSingleResponse(context.Background(), sess, ch, outputs{})
 	}
 }

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -148,7 +148,7 @@ func TestCheckBadConn(t *testing.T) {
 			params: msdsn.Config{},
 		},
 		sess: &tdsSession{
-			log: optionalCtxLogger{},
+			logger: optionalLogger{},
 		},
 	}
 

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -148,7 +148,7 @@ func TestCheckBadConn(t *testing.T) {
 	for _, ti := range testInputs {
 		c.connectionGood = true
 		c.connector.params.DisableRetry = ti.disableRetry
-		actualErr := c.checkBadConn(ti.err, ti.mayRetry)
+		actualErr := c.checkBadConn(context.Background(), ti.err, ti.mayRetry)
 		if !equalErrors(actualErr, ti.expectedErr) ||
 			c.connectionGood != ti.expectedConnGood {
 			t.Fatalf("checkBadConn returned unexpected result for input err = '%+v', mayRetry = '%t', disableRetry = '%t': "+
@@ -160,7 +160,7 @@ func TestCheckBadConn(t *testing.T) {
 
 	// This must be the final test in this function, because we expect it to panic
 	defer func() { recover() }()
-	c.checkBadConn(driver.ErrBadConn, true)
+	c.checkBadConn(context.Background(), driver.ErrBadConn, true)
 	t.Fatalf("checkBadConn did not panic as expected when passed driverErrBadConn")
 }
 

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestBadOpen(t *testing.T) {
-	drv := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	drv := driverWithProcess(t, &tl)
 	_, err := drv.open(context.Background(), "port=bad")
 	if err == nil {
 		t.Fail()

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -143,7 +143,14 @@ func TestCheckBadConn(t *testing.T) {
 		{goodConnErr, true, true, goodConnErr, true},
 	}
 
-	c := Conn{connector: &Connector{params: msdsn.Config{}}}
+	c := Conn{
+		connector: &Connector{
+			params: msdsn.Config{},
+		},
+		sess: &tdsSession{
+			log: optionalCtxLogger{},
+		},
+	}
 
 	for _, ti := range testInputs {
 		c.connectionGood = true

--- a/net_go116_test.go
+++ b/net_go116_test.go
@@ -56,7 +56,9 @@ func TestTimeoutConn(t *testing.T) {
 }
 
 func TestTLSHandshakeConn(t *testing.T) {
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	connector, err := NewConnector(makeConnStr(t).String())
 	if err != nil {
@@ -113,7 +115,9 @@ func TestTLSHandshakeConn(t *testing.T) {
 }
 
 func TestPassthroughConn(t *testing.T) {
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	connector, err := NewConnector(makeConnStr(t).String())
 	if err != nil {

--- a/queries_go110_test.go
+++ b/queries_go110_test.go
@@ -14,9 +14,8 @@ import (
 
 func TestSessionInitSQL(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
 
-	d := &Driver{}
+	d := &Driver{log: optionalCtxLogger{loggerAdapter{testLogger{t}}}}
 	connector, err := d.OpenConnector(makeConnStr(t).String())
 	if err != nil {
 		t.Fatal("unable to open connector", err)

--- a/queries_go110_test.go
+++ b/queries_go110_test.go
@@ -15,7 +15,7 @@ import (
 func TestSessionInitSQL(t *testing.T) {
 	checkConnStr(t)
 
-	d := &Driver{log: optionalCtxLogger{loggerAdapter{testLogger{t}}}}
+	d := &Driver{logger: optionalLogger{loggerAdapter{testLogger{t}}}}
 	connector, err := d.OpenConnector(makeConnStr(t).String())
 	if err != nil {
 		t.Fatal("unable to open connector", err)

--- a/queries_go110_test.go
+++ b/queries_go110_test.go
@@ -15,7 +15,9 @@ import (
 func TestSessionInitSQL(t *testing.T) {
 	checkConnStr(t)
 
-	d := &Driver{logger: optionalLogger{loggerAdapter{testLogger{t}}}}
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	d := &Driver{logger: optionalLogger{loggerAdapter{&tl}}}
 	connector, err := d.OpenConnector(makeConnStr(t).String())
 	if err != nil {
 		t.Fatal("unable to open connector", err)
@@ -188,8 +190,9 @@ select
 }
 
 func TestReturnStatusWithQuery(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	_, err := conn.Exec("if object_id('retstatus') is not null drop proc retstatus;")
 	if err != nil {
@@ -224,8 +227,9 @@ func TestReturnStatusWithQuery(t *testing.T) {
 }
 
 func TestIdentity(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	tx, err := conn.Begin()
 	if err != nil {

--- a/queries_go110pre_test.go
+++ b/queries_go110pre_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 func TestIdentity(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	tx, err := conn.Begin()
 	if err != nil {

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestOutputParam(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	db, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {
@@ -365,7 +367,9 @@ END;
 	sqltextrun := `abinout`
 
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	db, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {
@@ -565,7 +569,9 @@ func TestOutputParamWithRows(t *testing.T) {
 	sqltextrun := `spwithoutputandrows`
 
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	db, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {
@@ -614,7 +620,9 @@ func TestOutputParamWithRows(t *testing.T) {
 
 func TestParamNoName(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	db, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {
@@ -939,8 +947,9 @@ with
 	`
 	t.Logf("query len (utf16 bytes)=%d, len/4096=%f\n", len(query)*2, float64(len(query)*2)/4096)
 
-	db := open(t)
+	db, logger := open(t)
 	defer db.Close()
+	defer logger.StopLogging()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1000,8 +1009,9 @@ with
 }
 
 func TestDateTimeParam19(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	logger.StopLogging()
 
 	// testing DateTime1, only supported on go 1.9
 	var emptydate time.Time
@@ -1035,8 +1045,9 @@ func TestDateTimeParam19(t *testing.T) {
 }
 
 func TestReturnStatus(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	_, err := conn.Exec("if object_id('retstatus') is not null drop proc retstatus;")
 	if err != nil {
@@ -1059,8 +1070,9 @@ func TestReturnStatus(t *testing.T) {
 }
 
 func TestClearReturnStatus(t *testing.T) {
-	db := open(t)
+	db, logger := open(t)
 	defer db.Close()
+	defer logger.StopLogging()
 
 	ctx := context.TODO()
 	conn, err := db.Conn(ctx)

--- a/queries_test.go
+++ b/queries_test.go
@@ -21,7 +21,7 @@ import (
 
 func driverWithProcess(t *testing.T) *Driver {
 	return &Driver{
-		log:              optionalCtxLogger{loggerAdapter{testLogger{t}}},
+		logger:           optionalLogger{loggerAdapter{testLogger{t}}},
 		processQueryText: true,
 	}
 }

--- a/queries_test.go
+++ b/queries_test.go
@@ -21,7 +21,7 @@ import (
 
 func driverWithProcess(t *testing.T) *Driver {
 	return &Driver{
-		log:              optionalLogger{testLogger{t}},
+		log:              optionalCtxLogger{loggerAdapter{testLogger{t}}},
 		processQueryText: true,
 	}
 }
@@ -1313,7 +1313,7 @@ func TestProcessQueryErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal("prepareContext expected to succeed, but it failed with", err)
 	}
-	err = stmt.sendQuery([]namedValue{})
+	err = stmt.sendQuery(context.Background(), []namedValue{})
 	if err != nil {
 		t.Fatal("sendQuery expected to succeed, but it failed with", err)
 	}
@@ -1900,7 +1900,7 @@ func TestQueryCancelLowLevel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Prepare failed with error %v", err)
 	}
-	err = stmt.sendQuery([]namedValue{})
+	err = stmt.sendQuery(context.Background(), []namedValue{})
 	if err != nil {
 		t.Fatalf("sendQuery failed with error %v", err)
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -2661,8 +2661,10 @@ func TestClose(t *testing.T) {
 }
 
 func TestTypeSizesFromQuery(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
+
 	r, err := conn.Query("SELECT CAST('1' AS CHAR(10)), CAST(0x02 AS BINARY(20)), CAST(0x03 AS VARBINARY(30))")
 	if err != nil {
 		t.Fatal(err)

--- a/queries_test.go
+++ b/queries_test.go
@@ -1909,8 +1909,8 @@ func TestMixedParameters(t *testing.T) {
 /*
 func TestMixedParametersExample(t *testing.T) {
 	conn, logger := open(t)
-defer conn.Close()
-defer logger.StopLogging()
+	defer conn.Close()
+	defer logger.StopLogging()
 	row := conn.QueryRow(
 		"select :id, ?",
 		sql.Named("id", 1),

--- a/queries_test.go
+++ b/queries_test.go
@@ -19,16 +19,17 @@ import (
 	"github.com/denisenkom/go-mssqldb/msdsn"
 )
 
-func driverWithProcess(t *testing.T) *Driver {
+func driverWithProcess(t *testing.T, tl Logger) *Driver {
 	return &Driver{
-		logger:           optionalLogger{loggerAdapter{testLogger{t}}},
+		logger:           optionalLogger{loggerAdapter{tl}},
 		processQueryText: true,
 	}
 }
 
 func TestSelect(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	t.Run("scan into interface{}", func(t *testing.T) {
 		type testStruct struct {
@@ -216,8 +217,9 @@ func TestSelectDateTimeOffset(t *testing.T) {
 			time.Date(9999, 12, 31, 23, 59, 59, 999999900, time.FixedZone("", 0))},
 	}
 
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	for _, test := range values {
 		row := conn.QueryRow("select " + test.sql)
 		var retval interface{}
@@ -239,8 +241,9 @@ func TestSelectDateTimeOffset(t *testing.T) {
 }
 
 func TestSelectNewTypes(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	var ver string
 	err := conn.QueryRow("select SERVERPROPERTY('productversion')").Scan(&ver)
 	if err != nil {
@@ -318,8 +321,9 @@ func TestSelectNewTypes(t *testing.T) {
 }
 
 func TestTrans(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	var tx *sql.Tx
 	var err error
@@ -342,8 +346,9 @@ func TestTrans(t *testing.T) {
 }
 
 func TestNull(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	t.Run("scan into interface{}", func(t *testing.T) {
 		types := []string{
@@ -496,8 +501,9 @@ func TestParams(t *testing.T) {
 		testdate.UTC(),
 	}
 
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	for _, val := range values {
 		t.Run(fmt.Sprintf("%T:%#v", val, val), func(t *testing.T) {
@@ -531,8 +537,9 @@ func TestParams(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	res, err := conn.Exec("create table #abc (fld int)")
 	if err != nil {
@@ -546,7 +553,9 @@ func TestShortTimeout(t *testing.T) {
 		t.Skip("short")
 	}
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 	dsn := makeConnStr(t)
 	dsnParams := dsn.Query()
 	dsnParams.Set("Connection Timeout", "2")
@@ -575,8 +584,9 @@ func TestShortTimeout(t *testing.T) {
 }
 
 func TestTwoQueries(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	rows, err := conn.Query("select 1")
 	if err != nil {
@@ -616,8 +626,9 @@ func TestTwoQueries(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	row, err := conn.Query("exec bad")
 	if err == nil {
@@ -635,8 +646,9 @@ func TestError(t *testing.T) {
 }
 
 func TestMultipleErrors(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	row, err := conn.Query("create table #bad(bad int null primary key)")
 	if err == nil {
@@ -668,8 +680,9 @@ func TestMultipleErrors(t *testing.T) {
 }
 
 func TestQueryNoRows(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	var rows *sql.Rows
 	var err error
@@ -683,8 +696,9 @@ func TestQueryNoRows(t *testing.T) {
 }
 
 func TestQueryManyNullsRow(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	var row *sql.Row
 	var err error
@@ -698,8 +712,9 @@ func TestQueryManyNullsRow(t *testing.T) {
 }
 
 func TestOrderBy(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	tx, err := conn.Begin()
 	if err != nil {
@@ -747,8 +762,9 @@ func TestOrderBy(t *testing.T) {
 }
 
 func TestScanDecimal(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	var f float64
 	err := conn.QueryRow("select cast(0.5 as numeric(25,1))").Scan(&f)
@@ -774,8 +790,9 @@ func TestScanDecimal(t *testing.T) {
 }
 
 func TestAffectedRows(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	tx, err := conn.Begin()
 	if err != nil {
@@ -828,8 +845,9 @@ func queryParamRoundTrip(db *sql.DB, param interface{}, dest interface{}) {
 }
 
 func TestDateTimeParam(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	type testStruct struct {
 		t time.Time
 	}
@@ -870,8 +888,9 @@ func TestDateTimeParam(t *testing.T) {
 }
 
 func TestUniqueIdentifierParam(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	type testStruct struct {
 		name string
 		uuid interface{}
@@ -911,8 +930,9 @@ func TestUniqueIdentifierParam(t *testing.T) {
 }
 
 func TestBigQuery(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	func() {
 		rows, err := conn.Query(`WITH n(n) AS
@@ -941,8 +961,9 @@ func TestBigQuery(t *testing.T) {
 }
 
 func TestBug32(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	tx, err := conn.Begin()
 	if err != nil {
@@ -967,8 +988,9 @@ func TestBug32(t *testing.T) {
 }
 
 func TestIgnoreEmptyResults(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	rows, err := conn.Query("set nocount on; select 2")
 	if err != nil {
 		t.Fatal("Query failed", err.Error())
@@ -989,7 +1011,9 @@ func TestIgnoreEmptyResults(t *testing.T) {
 
 func TestStmt_SetQueryNotification(t *testing.T) {
 	checkConnStr(t)
-	mssqldriver := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	mssqldriver := driverWithProcess(t, &tl)
 	cn, err := mssqldriver.Open(makeConnStr(t).String())
 	if err != nil {
 		t.Fatalf("failed to open connection: %v", err)
@@ -1011,8 +1035,9 @@ func TestStmt_SetQueryNotification(t *testing.T) {
 }
 
 func TestErrorInfo(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	_, err := conn.Exec("select bad")
 	if sqlError, ok := err.(Error); ok {
@@ -1051,8 +1076,9 @@ func TestErrorInfo(t *testing.T) {
 }
 
 func TestSetLanguage(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	// sp_reset_connection is called when reusing a pooled connection
 	// which resets all SET values to defaults. Thus we can only
@@ -1068,8 +1094,9 @@ func TestSetLanguage(t *testing.T) {
 }
 
 func TestConnectionClosing(t *testing.T) {
-	pool := open(t)
+	pool, logger := open(t)
 	defer pool.Close()
+	defer logger.StopLogging()
 	for i := 1; i <= 100; i++ {
 		if pool.Stats().OpenConnections > 1 {
 			t.Errorf("Open connections is expected to stay <= 1, but it is %d", pool.Stats().OpenConnections)
@@ -1095,7 +1122,9 @@ func TestConnectionClosing(t *testing.T) {
 
 func TestBeginTranError(t *testing.T) {
 	checkConnStr(t)
-	drv := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	drv := driverWithProcess(t, &tl)
 	conn, err := drv.open(context.Background(), makeConnStr(t).String())
 	if err != nil {
 		t.Fatalf("Open failed with error %v", err)
@@ -1138,7 +1167,9 @@ func TestBeginTranError(t *testing.T) {
 
 func TestCommitTranError(t *testing.T) {
 	checkConnStr(t)
-	drv := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	drv := driverWithProcess(t, &tl)
 	conn, err := drv.open(context.Background(), makeConnStr(t).String())
 	if err != nil {
 		t.Fatalf("Open failed with error %v", err)
@@ -1196,7 +1227,9 @@ func TestCommitTranError(t *testing.T) {
 
 func TestRollbackTranError(t *testing.T) {
 	checkConnStr(t)
-	drv := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	drv := driverWithProcess(t, &tl)
 	conn, err := drv.open(context.Background(), makeConnStr(t).String())
 	if err != nil {
 		t.Fatalf("Open failed with error %v", err)
@@ -1259,7 +1292,9 @@ func TestRollbackTranError(t *testing.T) {
 
 func TestSendQueryErrors(t *testing.T) {
 	checkConnStr(t)
-	drv := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	drv := driverWithProcess(t, &tl)
 	conn, err := drv.open(context.Background(), makeConnStr(t).String())
 	if err != nil {
 		t.FailNow()
@@ -1297,9 +1332,9 @@ func TestSendQueryErrors(t *testing.T) {
 	}
 }
 
-func internalConnection(t *testing.T) *Conn {
+func internalConnection(t *testing.T, tl Logger) *Conn {
 	checkConnStr(t)
-	drv := driverWithProcess(t)
+	drv := driverWithProcess(t, tl)
 	conn, err := drv.open(context.Background(), makeConnStr(t).String())
 	if err != nil {
 		t.Fatal("open expected to succeed, but it failed with", err)
@@ -1308,7 +1343,9 @@ func internalConnection(t *testing.T) *Conn {
 }
 
 func TestProcessQueryErrors(t *testing.T) {
-	conn := internalConnection(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	conn := internalConnection(t, &tl)
 	stmt, err := conn.prepareContext(context.Background(), "select 1")
 	if err != nil {
 		t.Fatal("prepareContext expected to succeed, but it failed with", err)
@@ -1334,7 +1371,9 @@ func TestProcessQueryErrors(t *testing.T) {
 }
 
 func TestProcessQueryNextErrors(t *testing.T) {
-	conn := internalConnection(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	conn := internalConnection(t, &tl)
 	statements := make([]string, 1000)
 	for i := 0; i < len(statements); i++ {
 		statements[i] = "select 1"
@@ -1389,7 +1428,9 @@ func TestProcessQueryNextErrors(t *testing.T) {
 
 func TestSendExecErrors(t *testing.T) {
 	checkConnStr(t)
-	drv := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	drv := driverWithProcess(t, &tl)
 	conn, err := drv.open(context.Background(), makeConnStr(t).String())
 	if err != nil {
 		t.FailNow()
@@ -1472,8 +1513,9 @@ func TestLongConnection(t *testing.T) {
 }
 
 func TestNextResultSet(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	rows, err := conn.Query("select 1; select 2")
 	if err != nil {
 		t.Fatal("Query failed", err.Error())
@@ -1568,8 +1610,9 @@ func TestColumnTypeIntrospection(t *testing.T) {
 		{"cast(N'abc' as nchar(3))", "NCHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(1 as sql_variant)", "SQL_VARIANT", reflect.TypeOf(nil), false, 0, false, 0, 0},
 	}
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	for _, tt := range tests {
 		rows, err := conn.Query("select " + tt.expr)
 		if err != nil {
@@ -1627,8 +1670,9 @@ func TestColumnIntrospection(t *testing.T) {
 		{"f2 varchar(15) not null", "f2", "VARCHAR", false, true, 15, false, 0, 0},
 		{"f3 decimal(5, 2) null", "f3", "DECIMAL", true, false, 0, true, 5, 2},
 	}
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	// making table variable with specified fields and making a select from it
 	exprs := make([]string, len(tests))
@@ -1688,8 +1732,9 @@ func TestColumnIntrospection(t *testing.T) {
 }
 
 func TestContext(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	opts := &sql.TxOptions{
 		Isolation: sql.LevelSerializable,
@@ -1746,8 +1791,9 @@ func TestContext(t *testing.T) {
 }
 
 func TestBeginTxtReadOnlyNotSupported(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	opts := &sql.TxOptions{ReadOnly: true}
 	_, err := conn.BeginTx(context.Background(), opts)
 	if err == nil {
@@ -1756,8 +1802,9 @@ func TestBeginTxtReadOnlyNotSupported(t *testing.T) {
 }
 
 func TestConn_BeginTx(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	_, err := conn.Exec("create table test (f int)")
 	defer conn.Exec("drop table test")
 	if err != nil {
@@ -1803,8 +1850,9 @@ func TestConn_BeginTx(t *testing.T) {
 }
 
 func TestNamedParameters(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	row := conn.QueryRow(
 		"select @param2, @param1, @param2",
 		sql.Named("param1", 1),
@@ -1821,8 +1869,9 @@ func TestNamedParameters(t *testing.T) {
 }
 
 func TestBadNamedParameters(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	row := conn.QueryRow(
 		"select :param2, :param1, :param2",
 		sql.Named("badparam1", 1),
@@ -1837,8 +1886,9 @@ func TestBadNamedParameters(t *testing.T) {
 }
 
 func TestMixedParameters(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	row := conn.QueryRow(
 		"select @p2, @param1, @param2",
 		5, // this parameter will be unused
@@ -1858,8 +1908,9 @@ func TestMixedParameters(t *testing.T) {
 
 /*
 func TestMixedParametersExample(t *testing.T) {
-	conn := open(t)
-	defer conn.Close()
+	conn, logger := open(t)
+defer conn.Close()
+defer logger.StopLogging()
 	row := conn.QueryRow(
 		"select :id, ?",
 		sql.Named("id", 1),
@@ -1878,8 +1929,9 @@ func TestMixedParametersExample(t *testing.T) {
 */
 
 func TestPinger(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	err := conn.Ping()
 	if err != nil {
 		t.Errorf("Failed to hit database")
@@ -1888,7 +1940,9 @@ func TestPinger(t *testing.T) {
 
 func TestQueryCancelLowLevel(t *testing.T) {
 	checkConnStr(t)
-	drv := driverWithProcess(t)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	drv := driverWithProcess(t, &tl)
 	conn, err := drv.open(context.Background(), makeConnStr(t).String())
 	if err != nil {
 		t.Fatalf("Open failed with error %v", err)
@@ -1931,8 +1985,9 @@ func TestQueryCancelLowLevel(t *testing.T) {
 }
 
 func TestQueryCancelHighLevel(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	latency, _ := getLatency(t)
@@ -1988,8 +2043,9 @@ func getLatency(t *testing.T) (latency time.Duration, increment time.Duration) {
 }
 
 func TestQueryTimeout(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	// 2 seconds should be enough time to complete the login
 	latency, _ := getLatency(t)
 	ctx, cancel := context.WithTimeout(context.Background(), latency+2000*time.Millisecond)
@@ -2010,8 +2066,9 @@ func TestQueryTimeout(t *testing.T) {
 
 // Regression test for #679
 func TestLoginTimeout(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
 	// Try to timeout during the login using a small delta from raw connect time
 	// In environments where latency is really low this degenerates into TestQueryTimeout
 	latency, increment := getLatency(t)
@@ -2038,7 +2095,9 @@ func TestLoginTimeout(t *testing.T) {
 }
 func TestDriverParams(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 	type sqlCmd struct {
 		Name   string
 		Driver string
@@ -2211,7 +2270,9 @@ func TestDisconnect1(t *testing.T) {
 		t.Skip("short")
 	}
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	// Revert to the normal dialer after the test is done.
 	normalCreateDialer := createDialer
@@ -2268,7 +2329,9 @@ func TestDisconnect2(t *testing.T) {
 		t.Skip("short")
 	}
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 	latency, _ := getLatency(t)
 
 	// Revert to the normal dialer after the test is done.
@@ -2339,7 +2402,9 @@ func TestDisconnect3(t *testing.T) {
 		t.Skip("short")
 	}
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	// Revert to the normal dialer creation function after the test is done.
 	normalCreateDialer := createDialer
@@ -2431,7 +2496,9 @@ func TestDisconnect4(t *testing.T) {
 		t.Skip("short")
 	}
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	// Revert to the normal dialer creation function after the test is done.
 	normalCreateDialer := createDialer
@@ -2523,7 +2590,9 @@ func TestDisconnect5(t *testing.T) {
 		t.Skip("short")
 	}
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	// Open a connection pool that holds a single connection to make sure all
 	// queries run on the same connection.
@@ -2578,7 +2647,8 @@ func TestDisconnect5(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
+	defer logger.StopLogging()
 
 	defer func() {
 		v := recover()

--- a/tds.go
+++ b/tds.go
@@ -140,7 +140,7 @@ type tdsSession struct {
 	columns      []columnStruct
 	tranid       uint64
 	logFlags     uint64
-	log          optionalLogger
+	log          ContextLogger
 	routedServer string
 	routedPort   uint16
 }
@@ -151,16 +151,6 @@ const (
 
 	// Default port if no port given.
 	defaultServerPort = 1433
-)
-
-const (
-	logErrors      = uint64(msdsn.LogErrors)
-	logMessages    = uint64(msdsn.LogMessages)
-	logRows        = uint64(msdsn.LogRows)
-	logSQL         = uint64(msdsn.LogSQL)
-	logParams      = uint64(msdsn.LogParams)
-	logTransaction = uint64(msdsn.LogTransaction)
-	logDebug       = uint64(msdsn.LogDebug)
 )
 
 type columnStruct struct {
@@ -974,7 +964,7 @@ func interpretPreloginResponse(p msdsn.Config, fe *featureExtFedAuth, fields map
 	return
 }
 
-func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, log optionalLogger, auth auth, fe *featureExtFedAuth, packetSize uint32) (l *login, err error) {
+func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, log ContextLogger, auth auth, fe *featureExtFedAuth, packetSize uint32) (l *login, err error) {
 	var typeFlags uint8
 	if p.ReadOnlyIntent {
 		typeFlags |= fReadOnlyIntent
@@ -992,13 +982,13 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, log optiona
 	switch {
 	case fe.FedAuthLibrary == fedAuthLibrarySecurityToken:
 		if uint64(p.LogFlags)&logDebug != 0 {
-			log.Println("Starting federated authentication using security token")
+			log.Log(ctx, msdsn.LogDebug, "Starting federated authentication using security token")
 		}
 
 		fe.FedAuthToken, err = c.securityTokenProvider(ctx)
 		if err != nil {
 			if uint64(p.LogFlags)&logDebug != 0 {
-				log.Printf("Failed to retrieve service principal token for federated authentication security token library: %v", err)
+				log.Log(ctx, msdsn.LogDebug, fmt.Sprintf("Failed to retrieve service principal token for federated authentication security token library: %v", err))
 			}
 			return nil, err
 		}
@@ -1007,14 +997,14 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, log optiona
 
 	case fe.FedAuthLibrary == fedAuthLibraryADAL:
 		if uint64(p.LogFlags)&logDebug != 0 {
-			log.Println("Starting federated authentication using ADAL")
+			log.Log(ctx, msdsn.LogDebug, "Starting federated authentication using ADAL")
 		}
 
 		l.FeatureExt.Add(fe)
 
 	case auth != nil:
 		if uint64(p.LogFlags)&logDebug != 0 {
-			log.Println("Starting SSPI login")
+			log.Log(ctx, msdsn.LogDebug, "Starting SSPI login")
 		}
 
 		l.SSPI, err = auth.InitialBytes()
@@ -1034,7 +1024,7 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, log optiona
 	return l, nil
 }
 
-func connect(ctx context.Context, c *Connector, log optionalLogger, p msdsn.Config) (res *tdsSession, err error) {
+func connect(ctx context.Context, c *Connector, log ContextLogger, p msdsn.Config) (res *tdsSession, err error) {
 	dialCtx := ctx
 	if p.DialTimeout >= 0 {
 		dt := p.DialTimeout
@@ -1050,7 +1040,7 @@ func connect(ctx context.Context, c *Connector, log optionalLogger, p msdsn.Conf
 		// both instance name and port specified
 		// when port is specified instance name is not used
 		// you should not provide instance name when you provide port
-		log.Println("WARN: You specified both instance name and port in the connection string, port will be used and instance name will be ignored")
+		log.Log(ctx, 0, "WARN: You specified both instance name and port in the connection string, port will be used and instance name will be ignored")
 	}
 	if len(p.Instance) > 0 {
 		p.Instance = strings.ToUpper(p.Instance)

--- a/tds.go
+++ b/tds.go
@@ -1036,11 +1036,11 @@ func connect(ctx context.Context, c *Connector, logger ContextLogger, p msdsn.Co
 		defer cancel()
 	}
 	// if instance is specified use instance resolution service
-	if len(p.Instance) > 0 && p.Port != 0 {
+	if len(p.Instance) > 0 && p.Port != 0 && uint64(p.LogFlags)&logDebug != 0 {
 		// both instance name and port specified
 		// when port is specified instance name is not used
 		// you should not provide instance name when you provide port
-		logger.Log(ctx, 0, "WARN: You specified both instance name and port in the connection string, port will be used and instance name will be ignored")
+		logger.Log(ctx, msdsn.LogDebug, "WARN: You specified both instance name and port in the connection string, port will be used and instance name will be ignored")
 	}
 	if len(p.Instance) > 0 {
 		p.Instance = strings.ToUpper(p.Instance)

--- a/tds_go110_test.go
+++ b/tds_go110_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 )
 
-func open(t *testing.T) *sql.DB {
+func open(t *testing.T) (*sql.DB, *testLogger) {
+	tl := testLogger{t: t}
+	SetLogger(&tl)
 	checkConnStr(t)
-	SetLogger(testLogger{t})
 	connector, err := NewConnector(makeConnStr(t).String())
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
-		return nil
+		return nil, &tl
 	}
-	return sql.OpenDB(connector)
+	return sql.OpenDB(connector), &tl
 }

--- a/tds_go110_test.go
+++ b/tds_go110_test.go
@@ -16,5 +16,6 @@ func open(t *testing.T) (*sql.DB, *testLogger) {
 		t.Error("Open connection failed:", err.Error())
 		return nil, &tl
 	}
-	return sql.OpenDB(connector), &tl
+	conn := sql.OpenDB(connector)
+	return conn, &tl
 }

--- a/tds_go110pre_test.go
+++ b/tds_go110pre_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 )
 
-func open(t *testing.T) *sql.DB {
+func open(t *testing.T) (*sql.DB, *testLogger) {
+	tl := testLogger{t: t}
+	SetLogger(&tl)
 	checkConnStr(t)
-	SetLogger(testLogger{t})
 	conn, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
-		return nil
+		return nil, &tl
 	}
-	return conn
+	return conn, &tl
 }

--- a/tds_login_test.go
+++ b/tds_login_test.go
@@ -115,7 +115,9 @@ func TestLoginWithSQLServerAuth(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to parse dummy DSN: %v", err)
 	}
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	mock := NewMockTransportDialer(
 		[]string{
@@ -173,7 +175,9 @@ func TestLoginWithSecurityTokenAuth(t *testing.T) {
 		t.Errorf("Unable to parse dummy DSN: %v", err)
 	}
 
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	mock := NewMockTransportDialer(
 		[]string{
@@ -234,7 +238,9 @@ func TestLoginWithADALUsernamePasswordAuth(t *testing.T) {
 		t.Errorf("Unable to parse dummy DSN: %v", err)
 	}
 
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	mock := NewMockTransportDialer(
 		[]string{
@@ -306,7 +312,9 @@ func TestLoginWithADALManagedIdentityAuth(t *testing.T) {
 		t.Errorf("Unable to parse dummy DSN: %v", err)
 	}
 
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	mock := NewMockTransportDialer(
 		[]string{

--- a/tds_login_test.go
+++ b/tds_login_test.go
@@ -148,7 +148,7 @@ func TestLoginWithSQLServerAuth(t *testing.T) {
 
 	conn.Dialer = mock
 
-	_, err = connect(context.Background(), conn, driverInstanceNoProcess.log, conn.params)
+	_, err = connect(context.Background(), conn, driverInstanceNoProcess.logger, conn.params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -207,7 +207,7 @@ func TestLoginWithSecurityTokenAuth(t *testing.T) {
 
 	conn.Dialer = mock
 
-	_, err = connect(context.Background(), conn, driverInstanceNoProcess.log, conn.params)
+	_, err = connect(context.Background(), conn, driverInstanceNoProcess.logger, conn.params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -279,7 +279,7 @@ func TestLoginWithADALUsernamePasswordAuth(t *testing.T) {
 
 	conn.Dialer = mock
 
-	_, err = connect(context.Background(), conn, driverInstanceNoProcess.log, conn.params)
+	_, err = connect(context.Background(), conn, driverInstanceNoProcess.logger, conn.params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -351,7 +351,7 @@ func TestLoginWithADALManagedIdentityAuth(t *testing.T) {
 
 	conn.Dialer = mock
 
-	_, err = connect(context.Background(), conn, driverInstanceNoProcess.log, conn.params)
+	_, err = connect(context.Background(), conn, driverInstanceNoProcess.logger, conn.params)
 	if err != nil {
 		t.Error(err)
 	}

--- a/tds_test.go
+++ b/tds_test.go
@@ -156,7 +156,7 @@ func TestSendSqlBatch(t *testing.T) {
 		return
 	}
 
-	conn, err := connect(context.Background(), &Connector{params: p}, optionalCtxLogger{loggerAdapter{testLogger{t}}}, p)
+	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{loggerAdapter{testLogger{t}}}, p)
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
 		return
@@ -625,7 +625,7 @@ func BenchmarkPacketSize(b *testing.B) {
 }
 
 func runBatch(t testing.TB, p msdsn.Config) {
-	conn, err := connect(context.Background(), &Connector{params: p}, optionalCtxLogger{loggerAdapter{testLogger{t}}}, p)
+	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{loggerAdapter{testLogger{t}}}, p)
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
 		return

--- a/tds_test.go
+++ b/tds_test.go
@@ -258,7 +258,6 @@ type testLogger struct {
 }
 
 func (l *testLogger) Printf(format string, v ...interface{}) {
-	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if !l.done {
@@ -268,7 +267,6 @@ func (l *testLogger) Printf(format string, v ...interface{}) {
 }
 
 func (l *testLogger) Println(v ...interface{}) {
-	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if !l.done {

--- a/tds_test.go
+++ b/tds_test.go
@@ -156,7 +156,7 @@ func TestSendSqlBatch(t *testing.T) {
 		return
 	}
 
-	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{testLogger{t}}, p)
+	conn, err := connect(context.Background(), &Connector{params: p}, optionalCtxLogger{loggerAdapter{testLogger{t}}}, p)
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
 		return
@@ -625,7 +625,7 @@ func BenchmarkPacketSize(b *testing.B) {
 }
 
 func runBatch(t testing.TB, p msdsn.Config) {
-	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{testLogger{t}}, p)
+	conn, err := connect(context.Background(), &Connector{params: p}, optionalCtxLogger{loggerAdapter{testLogger{t}}}, p)
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
 		return

--- a/tds_test.go
+++ b/tds_test.go
@@ -6,12 +6,15 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
 	"os"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/denisenkom/go-mssqldb/msdsn"
 )
@@ -156,7 +159,9 @@ func TestSendSqlBatch(t *testing.T) {
 		return
 	}
 
-	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{loggerAdapter{testLogger{t}}}, p)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{loggerAdapter{&tl}}, p)
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
 		return
@@ -246,15 +251,33 @@ func makeConnStr(t testing.TB) *url.URL {
 }
 
 type testLogger struct {
-	t testing.TB
+	t    testing.TB
+	mu   sync.Mutex
+	done bool
 }
 
-func (l testLogger) Printf(format string, v ...interface{}) {
-	l.t.Logf(format, v...)
+func (l *testLogger) Printf(format string, v ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.done {
+		msg := fmt.Sprintf(format, v...)
+		l.t.Logf("%v: %s", time.Now(), msg)
+	}
 }
 
-func (l testLogger) Println(v ...interface{}) {
-	l.t.Log(v...)
+func (l *testLogger) Println(v ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.done {
+		msg := fmt.Sprint(v...)
+		l.t.Logf("%v: %s", time.Now(), msg)
+	}
+}
+
+func (l *testLogger) StopLogging() {
+	l.mu.Lock()
+	l.done = true
+	l.mu.Unlock()
 }
 
 func testConnection(t *testing.T, connStr string) {
@@ -277,7 +300,9 @@ func testConnection(t *testing.T, connStr string) {
 
 func TestConnect(t *testing.T) {
 	params := testConnParams(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 	testConnection(t, params.URL().String())
 }
 
@@ -327,11 +352,16 @@ func checkSimpleQuery(rows *sql.Rows, t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	if conn == nil {
 		return
 	}
 	defer conn.Close()
+	defer logger.StopLogging()
+
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	stmt := simpleQuery(conn, t)
 	if stmt == nil {
@@ -358,8 +388,13 @@ func TestQuery(t *testing.T) {
 
 func TestMultipleQueriesSequentialy(t *testing.T) {
 
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
+
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	stmt, err := conn.Prepare("select 1 as a")
 	if err != nil {
@@ -386,8 +421,13 @@ func TestMultipleQueriesSequentialy(t *testing.T) {
 }
 
 func TestMultipleQueryClose(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
+
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	stmt, err := conn.Prepare("select 1 as a")
 	if err != nil {
@@ -415,14 +455,22 @@ func TestMultipleQueryClose(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
-	conn := open(t)
+	conn, logger := open(t)
 	defer conn.Close()
+	defer logger.StopLogging()
+
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
+
 	conn.Ping()
 }
 
 func TestSecureWithInvalidHostName(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	dsn := makeConnStr(t)
 	dsnParams := dsn.Query()
@@ -444,7 +492,9 @@ func TestSecureWithInvalidHostName(t *testing.T) {
 
 func TestSecureConnection(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	dsn := makeConnStr(t)
 	dsnParams := dsn.Query()
@@ -625,7 +675,9 @@ func BenchmarkPacketSize(b *testing.B) {
 }
 
 func runBatch(t testing.TB, p msdsn.Config) {
-	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{loggerAdapter{testLogger{t}}}, p)
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	conn, err := connect(context.Background(), &Connector{params: p}, optionalLogger{loggerAdapter{&tl}}, p)
 	if err != nil {
 		t.Error("Open connection failed:", err.Error())
 		return

--- a/token.go
+++ b/token.go
@@ -369,7 +369,9 @@ func processEnvChg(ctx context.Context, sess *tdsSession) {
 			sess.routedPort = newPort
 		default:
 			// ignore rest of records because we don't know how to skip those
-			sess.logger.Log(ctx, 0, fmt.Sprintf("WARN: Unknown ENVCHANGE record detected with type id = %d", envtype))
+			if sess.logFlags&logDebug != 0 {
+				sess.logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("WARN: Unknown ENVCHANGE record detected with type id = %d", envtype))
+			}
 			return
 		}
 	}

--- a/token.go
+++ b/token.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"io/ioutil"
 	"strconv"
+
+	"github.com/denisenkom/go-mssqldb/msdsn"
 )
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type token
@@ -115,7 +117,7 @@ type doneInProcStruct doneStruct
 
 // ENVCHANGE stream
 // http://msdn.microsoft.com/en-us/library/dd303449.aspx
-func processEnvChg(sess *tdsSession) {
+func processEnvChg(ctx context.Context, sess *tdsSession) {
 	size := sess.buf.uint16()
 	r := &io.LimitedReader{R: sess.buf, N: int64(size)}
 	for {
@@ -233,7 +235,7 @@ func processEnvChg(sess *tdsSession) {
 				badStreamPanic(err)
 			}
 			if sess.logFlags&logTransaction != 0 {
-				sess.log.Printf("BEGIN TRANSACTION %x\n", sess.tranid)
+				sess.log.Log(ctx, msdsn.LogTransaction, fmt.Sprintf("BEGIN TRANSACTION %x", sess.tranid))
 			}
 			_, err = readBVarByte(r)
 			if err != nil {
@@ -250,9 +252,9 @@ func processEnvChg(sess *tdsSession) {
 			}
 			if sess.logFlags&logTransaction != 0 {
 				if envtype == envTypCommitTran {
-					sess.log.Printf("COMMIT TRANSACTION %x\n", sess.tranid)
+					sess.log.Log(ctx, msdsn.LogTransaction, fmt.Sprintf("COMMIT TRANSACTION %x", sess.tranid))
 				} else {
-					sess.log.Printf("ROLLBACK TRANSACTION %x\n", sess.tranid)
+					sess.log.Log(ctx, msdsn.LogTransaction, fmt.Sprintf("ROLLBACK TRANSACTION %x", sess.tranid))
 				}
 			}
 			sess.tranid = 0
@@ -367,7 +369,7 @@ func processEnvChg(sess *tdsSession) {
 			sess.routedPort = newPort
 		default:
 			// ignore rest of records because we don't know how to skip those
-			sess.log.Printf("WARN: Unknown ENVCHANGE record detected with type id = %d\n", envtype)
+			sess.log.Log(ctx, 0, fmt.Sprintf("WARN: Unknown ENVCHANGE record detected with type id = %d", envtype))
 			return
 		}
 	}
@@ -638,11 +640,11 @@ func parseReturnValue(r *tdsBuffer) (nv namedValue) {
 	return
 }
 
-func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs outputs) {
+func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenStruct, outs outputs) {
 	defer func() {
 		if err := recover(); err != nil {
 			if sess.logFlags&logErrors != 0 {
-				sess.log.Printf("ERROR: Intercepted panic %v", err)
+				sess.log.Log(ctx, msdsn.LogErrors, fmt.Sprintf("ERROR: Intercepted panic %v", err))
 			}
 			ch <- err
 		}
@@ -652,7 +654,7 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs outputs) 
 	packet_type, err := sess.buf.BeginRead()
 	if err != nil {
 		if sess.logFlags&logErrors != 0 {
-			sess.log.Printf("ERROR: BeginRead failed %v", err)
+			sess.log.Log(ctx, msdsn.LogErrors, fmt.Sprintf("ERROR: BeginRead failed %v", err))
 		}
 		ch <- err
 		return
@@ -665,7 +667,7 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs outputs) 
 	for tokens := 0; ; tokens += 1 {
 		token := token(sess.buf.byte())
 		if sess.logFlags&logDebug != 0 {
-			sess.log.Printf("got token %v", token)
+			sess.log.Log(ctx, msdsn.LogDebug, fmt.Sprintf("got token %v", token))
 		}
 		switch token {
 		case tokenSSPI:
@@ -689,21 +691,21 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs outputs) 
 		case tokenDoneInProc:
 			done := parseDoneInProc(sess.buf)
 			if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {
-				sess.log.Printf("(%d row(s) affected)\n", done.RowCount)
+				sess.log.Log(ctx, msdsn.LogRows, fmt.Sprintf("(%d row(s) affected)", done.RowCount))
 			}
 			ch <- done
 		case tokenDone, tokenDoneProc:
 			done := parseDone(sess.buf)
 			done.errors = errs
 			if sess.logFlags&logDebug != 0 {
-				sess.log.Printf("got DONE or DONEPROC status=%d", done.Status)
+				sess.log.Log(ctx, msdsn.LogDebug, fmt.Sprintf("got DONE or DONEPROC status=%d", done.Status))
 			}
 			if done.Status&doneSrvError != 0 {
 				ch <- ServerError{done.getError()}
 				return
 			}
 			if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {
-				sess.log.Printf("(%d row(s) affected)\n", done.RowCount)
+				sess.log.Log(ctx, msdsn.LogRows, fmt.Sprintf("(%d row(s) affected)", done.RowCount))
 			}
 			ch <- done
 			if done.Status&doneMore == 0 {
@@ -721,23 +723,23 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs outputs) 
 			parseNbcRow(sess.buf, columns, row)
 			ch <- row
 		case tokenEnvChange:
-			processEnvChg(sess)
+			processEnvChg(ctx, sess)
 		case tokenError:
 			err := parseError72(sess.buf)
 			if sess.logFlags&logDebug != 0 {
-				sess.log.Printf("got ERROR %d %s", err.Number, err.Message)
+				sess.log.Log(ctx, msdsn.LogDebug, fmt.Sprintf("got ERROR %d %s", err.Number, err.Message))
 			}
 			errs = append(errs, err)
 			if sess.logFlags&logErrors != 0 {
-				sess.log.Println(err.Message)
+				sess.log.Log(ctx, msdsn.LogErrors, err.Message)
 			}
 		case tokenInfo:
 			info := parseInfo(sess.buf)
 			if sess.logFlags&logDebug != 0 {
-				sess.log.Printf("got INFO %d %s", info.Number, info.Message)
+				sess.log.Log(ctx, msdsn.LogDebug, fmt.Sprintf("got INFO %d %s", info.Number, info.Message))
 			}
 			if sess.logFlags&logMessages != 0 {
-				sess.log.Println(info.Message)
+				sess.log.Log(ctx, msdsn.LogMessages, info.Message)
 			}
 		case tokenReturnValue:
 			nv := parseReturnValue(sess.buf)
@@ -771,7 +773,7 @@ type tokenProcessor struct {
 
 func startReading(sess *tdsSession, ctx context.Context, outs outputs) *tokenProcessor {
 	tokChan := make(chan tokenStruct, 5)
-	go processSingleResponse(sess, tokChan, outs)
+	go processSingleResponse(ctx, sess, tokChan, outs)
 	return &tokenProcessor{
 		tokChan: tokChan,
 		ctx:     ctx,
@@ -874,7 +876,7 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 		// we did not get cancellation confirmation in the current response
 		// read one more response, it must be there
 		t.tokChan = make(chan tokenStruct, 5)
-		go processSingleResponse(t.sess, t.tokChan, t.outs)
+		go processSingleResponse(t.ctx, t.sess, t.tokChan, t.outs)
 		if readCancelConfirmation(t.tokChan) {
 			return nil, t.ctx.Err()
 		}

--- a/token.go
+++ b/token.go
@@ -646,7 +646,7 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 	defer func() {
 		if err := recover(); err != nil {
 			if sess.logFlags&logErrors != 0 {
-				sess.logger.Log(ctx, msdsn.LogErrors, fmt.Sprintf("ERROR: Intercepted panic %v", err))
+				sess.logger.Log(ctx, msdsn.LogErrors, fmt.Sprintf("Intercepted panic %v", err))
 			}
 			ch <- err
 		}
@@ -656,7 +656,7 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 	packet_type, err := sess.buf.BeginRead()
 	if err != nil {
 		if sess.logFlags&logErrors != 0 {
-			sess.logger.Log(ctx, msdsn.LogErrors, fmt.Sprintf("ERROR: BeginRead failed %v", err))
+			sess.logger.Log(ctx, msdsn.LogErrors, fmt.Sprintf("BeginRead failed %v", err))
 		}
 		ch <- err
 		return

--- a/tvp_go19_db_test.go
+++ b/tvp_go19_db_test.go
@@ -13,7 +13,9 @@ import (
 
 func TestTVPGoSQLTypesWithStandardType(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	c := makeConnStr(t).String()
 	db, err := sql.Open("sqlserver", c)
@@ -252,7 +254,9 @@ func TestTVPGoSQLTypesWithStandardType(t *testing.T) {
 
 func TestTVPGoSQLTypes(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	c := makeConnStr(t).String()
 	db, err := sql.Open("sqlserver", c)
@@ -413,7 +417,9 @@ func TestTVPGoSQLTypes(t *testing.T) {
 
 func TestTVP(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	c := makeConnStr(t).String()
 	db, err := sql.Open("sqlserver", c)
@@ -694,7 +700,9 @@ func TestTVP(t *testing.T) {
 
 func TestTVP_WithTag(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	db, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {
@@ -1037,7 +1045,9 @@ func TestTVPSchema(t *testing.T) {
 	)
 
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	conn, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {
@@ -1105,7 +1115,9 @@ func TestTVPSchema(t *testing.T) {
 
 func TestTVPObject(t *testing.T) {
 	checkConnStr(t)
-	SetLogger(testLogger{t})
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
 
 	conn, err := sql.Open("sqlserver", makeConnStr(t).String())
 	if err != nil {


### PR DESCRIPTION
This pull request resolves #680 and adds a ContextLogger interface to improve the capabilities of the existing Logger interface. Compared to the Logger interface, ContextLogger:

1. Supplies the context to the Log function, allowing the developer to include things such as trace IDs in the logged messages
2. Supplies the category of the message being logged, allowing the developer to handle different classes of messages differently (e.g. send debug messages to a file while sending error messages to a system log)
3. Allows the developer to decide whether or not to include prefixes such as "ERROR:" in the messages
4. Adds a LogRetries category that allows the developer to log errors that would otherwise be hidden by successful retries.

This pull request maintains the existing Logger for backwards compatibility. The developer can choose to use either interface, but not both at the same time. The last one set wins.

