### PR TITLE
keep tls config in sync with msdsn host

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1263,6 +1263,7 @@ initiate_connection:
 		p.Host = sess.routedServer
 		p.Port = uint64(sess.routedPort)
 		if !p.HostInCertificateProvided && p.TLSConfig != nil {
+			p.TLSConfig = p.TLSConfig.Clone()
 			p.TLSConfig.ServerName = sess.routedServer
 		}
 		goto initiate_connection


### PR DESCRIPTION
Fixes #482 
`p.TLSConfig` here is a pointer back to the original config, so we shouldn't overwrite its contents in this retry loop. Otherwise the `TLSConfig.ServerName` doesn't match `p.Host` on new connections for the first `Handshake` call.

@kardianos  once this is in can you create a 0.10.1 release for the AKS team at Microsoft to consume?
They want to pick up an official release with the fixes for bad connection marking.
