### PR TITLE
Fix an issue where Host is named instance name

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1253,7 +1253,7 @@ initiate_connection:
 		// Need to handle case when routedServer is in "host\instance" format.
 		routedParts := strings.SplitN(sess.routedServer, "\\", 2)
 		p.Host = routedParts[0]
-		if len(routedServer) == 2 {
+		if len(routedParts) == 2 {
 			p.Instance = routedParts[1]
 		}
 		p.Port = uint64(sess.routedPort)

--- a/tds.go
+++ b/tds.go
@@ -1259,7 +1259,7 @@ initiate_connection:
 		p.Port = uint64(sess.routedPort)
 		if !p.HostInCertificateProvided && p.TLSConfig != nil {
 			p.TLSConfig = p.TLSConfig.Clone()
-			p.TLSConfig.ServerName = sess.routedServer
+			p.TLSConfig.ServerName = p.Host
 		}
 		goto initiate_connection
 	}

--- a/tds.go
+++ b/tds.go
@@ -1250,8 +1250,8 @@ initiate_connection:
 
 	if sess.routedServer != "" {
 		toconn.Close()
-		// Need to handle case when routedServer is in "host\instance" format
-		routedParts := strings.SplitN(sess.routedServer, "\\", 2)
+		// Need to handle case when routedServer is in "host\instance" format.
+		var routedParts []string := strings.SplitN(sess.routedServer, "\\", 2)
 		p.Host = routedServer[0]
 		if len(routedServer) == 2 {
 			p.Instance = routedServer[1]

--- a/tds.go
+++ b/tds.go
@@ -847,7 +847,7 @@ func dialConnection(ctx context.Context, c *Connector, p msdsn.Config) (conn net
 	var ips []net.IP
 	ip := net.ParseIP(p.Host)
 	if ip == nil {
-		ips, err = net.LookupIP(p.Host)		
+		ips, err = net.LookupIP(p.Host)
 		if err != nil {
 			return
 		}
@@ -1250,8 +1250,8 @@ initiate_connection:
 
 	if sess.routedServer != "" {
 		toconn.Close()
-		var routedServer []string
-		routedServer = strings.Split(sess.routedServer, "\\")
+		// Need to handle case when routedServer is in "host\instance" format
+		routedParts := strings.SplitN(sess.routedServer, "\\", 2)
 		p.Host = routedServer[0]
 		if len(routedServer) == 2 {
 			p.Instance = routedServer[1]

--- a/tds.go
+++ b/tds.go
@@ -847,7 +847,8 @@ func dialConnection(ctx context.Context, c *Connector, p msdsn.Config) (conn net
 	var ips []net.IP
 	ip := net.ParseIP(p.Host)
 	if ip == nil {
-		ips, err = net.LookupIP(p.Host)
+		host := strings.Split(p.Host, "\\")[0]
+		ips, err = net.LookupIP(host)		
 		if err != nil {
 			return
 		}

--- a/tds.go
+++ b/tds.go
@@ -1251,10 +1251,10 @@ initiate_connection:
 	if sess.routedServer != "" {
 		toconn.Close()
 		// Need to handle case when routedServer is in "host\instance" format.
-		var routedParts []string := strings.SplitN(sess.routedServer, "\\", 2)
-		p.Host = routedServer[0]
+		routedParts := strings.SplitN(sess.routedServer, "\\", 2)
+		p.Host = routedParts[0]
 		if len(routedServer) == 2 {
-			p.Instance = routedServer[1]
+			p.Instance = routedParts[1]
 		}
 		p.Port = uint64(sess.routedPort)
 		if !p.HostInCertificateProvided && p.TLSConfig != nil {

--- a/tds.go
+++ b/tds.go
@@ -847,8 +847,7 @@ func dialConnection(ctx context.Context, c *Connector, p msdsn.Config) (conn net
 	var ips []net.IP
 	ip := net.ParseIP(p.Host)
 	if ip == nil {
-		host := strings.Split(p.Host, "\\")[0]
-		ips, err = net.LookupIP(host)		
+		ips, err = net.LookupIP(p.Host)		
 		if err != nil {
 			return
 		}
@@ -1251,7 +1250,12 @@ initiate_connection:
 
 	if sess.routedServer != "" {
 		toconn.Close()
-		p.Host = sess.routedServer
+		var routedServer []string
+		routedServer = strings.Split(sess.routedServer, "\\")
+		p.Host = routedServer[0]
+		if len(routedServer) == 2 {
+			p.Instance = routedServer[1]
+		}
 		p.Port = uint64(sess.routedPort)
 		if !p.HostInCertificateProvided && p.TLSConfig != nil {
 			p.TLSConfig = p.TLSConfig.Clone()


### PR DESCRIPTION
For Microsoft SQL Host could take form [server]\\[instance]. Without this fix LookupIP will fail in this scenario.