### PR TITLE
Performance Improvement in tds and ucs2 parsing

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"sync"
 )
 
 type packetType uint8
@@ -17,6 +18,11 @@ type header struct {
 	Pad        uint8
 }
 
+// bufpool provides buffers which are used for reading and writing in the tdsBuffer instances
+var bufpool = sync.Pool{
+	New: func() interface{} { return make([]byte, 1<<17) },
+}
+
 // tdsBuffer reads and writes TDS packets of data to the transport.
 // The write and read buffers are separate to make sending attn signals
 // possible without locks. Currently attn signals are only sent during
@@ -25,6 +31,9 @@ type tdsBuffer struct {
 	transport io.ReadWriteCloser
 
 	packetSize int
+
+	// bufClose is responsible for returning the buffer back to the pool
+	bufClose func()
 
 	// Write fields.
 	wbuf        []byte
@@ -46,13 +55,23 @@ type tdsBuffer struct {
 }
 
 func newTdsBuffer(bufsize uint16, transport io.ReadWriteCloser) *tdsBuffer {
+
+	// pull an existing buf if one is available or get and add a new buf to the bufpool
+	buf := bufpool.Get().([]byte)
+
 	return &tdsBuffer{
 		packetSize: int(bufsize),
-		wbuf:       make([]byte, bufsize),
-		rbuf:       make([]byte, bufsize),
+		wbuf:       buf[:1<<16],
+		rbuf:       buf[1<<16:],
+		bufClose:   func() { bufpool.Put(buf) },
 		rpos:       8,
 		transport:  transport,
 	}
+}
+
+func (rw *tdsBuffer) Close() {
+	rw.transport.Close()
+	rw.bufClose()
 }
 
 func (rw *tdsBuffer) ResizeBuffer(packetSize int) {
@@ -201,16 +220,27 @@ func (r *tdsBuffer) byte() byte {
 }
 
 func (r *tdsBuffer) ReadFull(buf []byte) {
-	_, err := io.ReadFull(r, buf[:])
+	_, err := io.ReadFull(r, buf)
 	if err != nil {
 		badStreamPanic(err)
 	}
 }
 
 func (r *tdsBuffer) uint64() uint64 {
-	var buf [8]byte
-	r.ReadFull(buf[:])
-	return binary.LittleEndian.Uint64(buf[:])
+	// have we got enough room in the buffer to read 8 bytes, if not, do a ReadFull, else read directly from r.rbuf
+	if r.rpos+7 >= r.rsize {
+		var buf [8]byte
+		r.ReadFull(buf[:])
+
+		return uint64(buf[0]) | uint64(buf[1])<<8 | uint64(buf[2])<<16 | uint64(buf[3])<<24 |
+			uint64(buf[4])<<32 | uint64(buf[5])<<40 | uint64(buf[6])<<48 | uint64(buf[7])<<56
+	}
+
+	res := uint64(r.rbuf[r.rpos]) | uint64(r.rbuf[r.rpos+1])<<8 | uint64(r.rbuf[r.rpos+2])<<16 | uint64(r.rbuf[r.rpos+3])<<24 |
+		uint64(r.rbuf[r.rpos+4])<<32 | uint64(r.rbuf[r.rpos+5])<<40 | uint64(r.rbuf[r.rpos+6])<<48 | uint64(r.rbuf[r.rpos+7])<<56
+
+	r.rpos += 8
+	return res
 }
 
 func (r *tdsBuffer) int32() int32 {
@@ -218,15 +248,29 @@ func (r *tdsBuffer) int32() int32 {
 }
 
 func (r *tdsBuffer) uint32() uint32 {
-	var buf [4]byte
-	r.ReadFull(buf[:])
-	return binary.LittleEndian.Uint32(buf[:])
+	// have we got enough room in the buffer to read 4 bytes, if not, do a ReadFull, else read directly from r.rbuf
+	if r.rpos+3 >= r.rsize {
+		var buf [4]byte
+		r.ReadFull(buf[:])
+		return uint32(buf[0]) | uint32(buf[1])<<8 | uint32(buf[2])<<16 | uint32(buf[3])<<24
+	}
+
+	res := uint32(r.rbuf[r.rpos]) | uint32(r.rbuf[r.rpos+1])<<8 | uint32(r.rbuf[r.rpos+2])<<16 | uint32(r.rbuf[r.rpos+3])<<24
+	r.rpos += 4
+	return res
 }
 
 func (r *tdsBuffer) uint16() uint16 {
-	var buf [2]byte
-	r.ReadFull(buf[:])
-	return binary.LittleEndian.Uint16(buf[:])
+	// have we got enough room in the buffer to read 2 bytes, if not, do a ReadFull, else read directly from r.rbuf
+	if r.rpos+1 >= r.rsize {
+		var buf [2]byte
+		r.ReadFull(buf[:])
+		return uint16(buf[0]) | uint16(buf[1])<<8
+	}
+
+	res := uint16(r.rbuf[r.rpos]) | uint16(r.rbuf[r.rpos+1])<<8
+	r.rpos += 2
+	return res
 }
 
 func (r *tdsBuffer) BVarChar() string {

--- a/buf.go
+++ b/buf.go
@@ -20,7 +20,7 @@ type header struct {
 
 // bufpool provides buffers which are used for reading and writing in the tdsBuffer instances
 var bufpool = sync.Pool{
-	New: func() interface{} { return make([]byte, 1<<17) },
+	New: func() interface{} { return make([]byte, 1<<16) },
 }
 
 // tdsBuffer reads and writes TDS packets of data to the transport.
@@ -61,8 +61,8 @@ func newTdsBuffer(bufsize uint16, transport io.ReadWriteCloser) *tdsBuffer {
 
 	return &tdsBuffer{
 		packetSize: int(bufsize),
-		wbuf:       buf[:1<<16],
-		rbuf:       buf[1<<16:],
+		wbuf:       buf[:1<<15],
+		rbuf:       buf[1<<15:],
 		bufClose:   func() { bufpool.Put(buf) },
 		rpos:       8,
 		transport:  transport,

--- a/buf_test.go
+++ b/buf_test.go
@@ -136,7 +136,7 @@ func makeLargeDataBuffer() []byte {
 func TestReadUint16Succeeds(t *testing.T) {
 
 	data := makeLargeDataBuffer()
-	size := 0x9 + (1 << 15)
+	size := 0x9 + (1 << 14)
 	buffer := makeBuf(uint16(size), append([]byte{0x01 /*id*/, 0xFF /*status*/, byte((size >> 8) & 0xFF), byte(size & 0xFF) /*size*/, 0xff, 0xff, 0xff, 0xff, 0xff /* byte pattern data to follow */}, data...))
 
 	id, err := buffer.BeginRead()
@@ -153,7 +153,7 @@ func TestReadUint16Succeeds(t *testing.T) {
 
 	defer func() {
 
-		if iterations != (1<<15)/4 {
+		if iterations != (1<<14)/4 {
 			t.Fatalf("Expected to read all data, but only read %v", iterations*4)
 		}
 
@@ -191,7 +191,7 @@ func TestReadUint16Succeeds(t *testing.T) {
 func TestReadUint32Succeeds(t *testing.T) {
 
 	data := makeLargeDataBuffer()
-	size := 0x9 + (1 << 15)
+	size := 0x9 + (1 << 14)
 	buffer := makeBuf(uint16(size), append([]byte{0x01 /*id*/, 0xFF /*status*/, byte((size >> 8) & 0xFF), byte(size & 0xFF) /*size*/, 0xff, 0xff, 0xff, 0xff, 0xff /* byte pattern data to follow */}, data...))
 
 	id, err := buffer.BeginRead()
@@ -206,7 +206,7 @@ func TestReadUint32Succeeds(t *testing.T) {
 
 	iterations := 0
 	defer func() {
-		if iterations != (1<<15)/4 {
+		if iterations != (1<<14)/4 {
 			t.Fatalf("Expected to read all data, but only read %v", iterations*4)
 		}
 
@@ -236,7 +236,7 @@ func TestReadUint32Succeeds(t *testing.T) {
 func TestReadUint64Succeeds(t *testing.T) {
 
 	data := makeLargeDataBuffer()
-	size := 0x9 + (1 << 15)
+	size := 0x9 + (1 << 14)
 	buffer := makeBuf(uint16(size), append([]byte{0x01 /*id*/, 0xFF /*status*/, byte((size >> 8) & 0xFF), byte(size & 0xFF) /*size*/, 0xff, 0xff, 0xff, 0xff, 0xff /* byte pattern data to follow */}, data...))
 
 	id, err := buffer.BeginRead()
@@ -251,7 +251,7 @@ func TestReadUint64Succeeds(t *testing.T) {
 
 	iterations := 0
 	defer func() {
-		if iterations != (1<<15)/8 {
+		if iterations != (1<<14)/8 {
 			t.Fatalf("Expected to read all data, but only read %v", iterations*4)
 		}
 

--- a/mssql.go
+++ b/mssql.go
@@ -413,6 +413,7 @@ func (d *Driver) connect(ctx context.Context, c *Connector, params msdsn.Config)
 }
 
 func (c *Conn) Close() error {
+	c.sess.buf.bufClose()
 	return c.sess.buf.transport.Close()
 }
 

--- a/tds.go
+++ b/tds.go
@@ -9,12 +9,14 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 	"unicode/utf16"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/denisenkom/go-mssqldb/msdsn"
 )
@@ -468,15 +470,137 @@ func str2ucs2(s string) []byte {
 	return ucs2
 }
 
+const (
+	mask64 uint64 = 0xFF80FF80FF80FF80
+	mask32 uint32 = 0xFF80FF80
+	mask16 uint16 = 0xFF80
+)
+
 func ucs22str(s []byte) (string, error) {
 	if len(s)%2 != 0 {
 		return "", fmt.Errorf("illegal UCS2 string length: %d", len(s))
 	}
-	buf := make([]uint16, len(s)/2)
-	for i := 0; i < len(s); i += 2 {
-		buf[i/2] = binary.LittleEndian.Uint16(s[i:])
+
+	// allocate a buffer which we will attempt to copy ascii into, optimistically, as we validate
+	buf := make([]byte, len(s)/2)
+	useFastPath := true
+
+	// how many 8 byte chunks are in the input buffer
+	nlen8 := len(s) & 0xFFFFFFF8
+	// our read and write offsets into the buffers
+	var readIndex int = 0
+	var writeIndex int = 0
+
+	// step through in 8 byte chunks.
+	for readIndex = 0; readIndex < nlen8; readIndex += 8 {
+
+		// defererence directly into the array as uint64s
+		ui64 := *(*uint64)(unsafe.Pointer(uintptr(unsafe.Pointer(&s[0])) + uintptr(readIndex)))
+
+		// mask the entire 64 bit region and check for
+		// 1) even bytes > 0
+		// 2) odd bytes with their high bit set
+		// the mask for this is FF80....
+		if ui64&mask64 > 0 {
+			// if we find a value once masked, we have to take the slow path as this is not an ascii string
+			useFastPath = false
+			break
+		}
+
+		// we are ok to read out the 4 odd bytes and remove the empty even bytes
+		var ui32 uint32 = 0
+		ui32 |= uint32(byte(ui64))
+		ui64 = ui64 >> 8
+
+		ui32 |= uint32(uint16(ui64))
+		ui64 = ui64 >> 8
+
+		ui32 |= uint32(ui64 & 0xFF0000)
+		ui64 = ui64 >> 8
+		ui32 |= uint32(ui64 & 0xFF000000)
+
+		// write the new 32 bit value to the destination buffer
+		ptrui32 := ((*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&buf[0])) + uintptr(writeIndex))))
+		*ptrui32 = ui32
+
+		// step forward four bytes in the destinaiton buffer
+		writeIndex += 4
 	}
-	return string(utf16.Decode(buf)), nil
+
+	// can we continue reading on the fast ascii path?
+	if useFastPath {
+		// we have now dealt with all the avalable 8 byte chunks, we have at most 7 bytes remaining.
+
+		// have we got at least 4 bytes remaining to be read?
+		if len(s)-readIndex >= 4 {
+			// deal with the next 32 bit region
+
+			// read 32 bits from the current read position in the source slice
+			ui32 := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&s[0])) + uintptr(readIndex)))
+
+			// mask the 32 bit value as above. again, if we find a value
+			// this is not ascii and we need to fall back to the slow path
+			// this time with a 32 bit mask
+			if ui32&mask32 > 0 {
+				// we have found non ascii text and must fallback
+				useFastPath = false
+			} else {
+
+				// read the two odd positions bytes and write as a single 16 bit value
+				var ui16 uint16 = 0
+				ui16 |= uint16(byte(ui32))
+				ui32 = ui32 >> 8
+
+				ui16 |= uint16(ui32)
+
+				ptrui16 := ((*uint16)(unsafe.Pointer(uintptr(unsafe.Pointer(&buf[0])) + uintptr((writeIndex)))))
+				*ptrui16 = ui16
+
+				// step forward the read and write positions.
+				readIndex += 4
+				writeIndex += 2
+			}
+		}
+
+		// Are we still on the fast path?
+		if useFastPath {
+			// have we got at least 2 bytes remaining to be read?
+			// actually we can only have at most 2 bytes at this point
+			// since we know the source buffer has even length.
+			if len(s)-readIndex >= 2 {
+
+				// read 2 bytes
+				ui16 := *(*uint16)(unsafe.Pointer(uintptr(unsafe.Pointer(&s[0])) + uintptr(readIndex)))
+
+				// mask again, but only 16bits
+				if ui16&mask16 == 0 {
+					// manually pull out the low byte and write to our destination buffer
+					buf[writeIndex] = byte(ui16 & 0xFF)
+					// we have now successfully read the entire ascii buffer and can convert to a string
+					return *(*string)(unsafe.Pointer(&buf)), nil
+				}
+			} else {
+				// there were no further bytes to read, but we have successfully read the ascii
+				// and can convert to a string
+				return *(*string)(unsafe.Pointer(&buf)), nil
+			}
+		}
+	}
+
+	// one of the above checks has found non ascii values in the buffer, either
+	// a high bit set in an odd byte or any non zero in an even byte.
+	// we fall back to a slower conversion here.
+
+	// we can reuse the underlying array and create our own uint16 slice here
+	// because utf16.Decode allocates a new buffer and only reads its input.
+	uint16slice := reflect.SliceHeader{
+		Data: (*reflect.SliceHeader)(unsafe.Pointer(&s)).Data,
+		Len:  len(s) / 2,
+		Cap:  len(s) / 2,
+	}
+	ptr := *(*[]uint16)(unsafe.Pointer(&uint16slice))
+
+	return string(utf16.Decode(ptr)), nil
 }
 
 func manglePassword(password string) []byte {
@@ -685,7 +809,7 @@ func writeUsVarChar(w io.Writer, s string) (err error) {
 	return
 }
 
-func readBVarChar(r io.Reader) (res string, err error) {
+func readBVarChar(r io.Reader) (string, error) {
 	numchars, err := readByte(r)
 	if err != nil {
 		return "", err

--- a/tds_test.go
+++ b/tds_test.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf16"
 
 	"github.com/denisenkom/go-mssqldb/msdsn"
 )
@@ -627,6 +628,162 @@ func TestUcs22Str(t *testing.T) {
 	_, err = ucs22str([]byte{0})
 	if err == nil {
 		t.Error("ucs22str should fail on single byte input, but it didn't")
+	}
+}
+
+var encoded123456789Bytes = []byte{0x31, 0, 0x32, 0, 0x33, 0, 0x34, 0, 0x35, 0, 0x36, 0, 0x37, 0, 0x38, 0, 0x39, 0}
+var encoded12345678Bytes = []byte{0x31, 0, 0x32, 0, 0x33, 0, 0x34, 0, 0x35, 0, 0x36, 0, 0x37, 0, 0x38, 0}
+var encoded1234567Bytes = []byte{0x31, 0, 0x32, 0, 0x33, 0, 0x34, 0, 0x35, 0, 0x36, 0, 0x37, 0}
+var encoded123456Bytes = []byte{0x31, 0, 0x32, 0, 0x33, 0, 0x34, 0, 0x35, 0, 0x36, 0}
+var encoded12345Bytes = []byte{0x31, 0, 0x32, 0, 0x33, 0, 0x34, 0, 0x35, 0}
+var encoded1234Bytes = []byte{0x31, 0, 0x32, 0, 0x33, 0, 0x34, 0}
+var encoded123Bytes = []byte{0x31, 0, 0x32, 0, 0x33, 0}
+var encoded12Bytes = []byte{0x31, 0, 0x32, 0}
+var encoded1Bytes = []byte{0x31, 0}
+
+var encodedLongASCIIBytes = []byte{0x31, 0, 0x32, 0, 0x33, 0, 0x34, 0, 0x35, 0, 0x36, 0, 0x37, 0, 0x38, 0, 0x39, 0,
+	// a-z
+	0x61, 0x0, 0x62, 0x0, 0x63, 0x0, 0x64, 0x0, 0x65, 0x0, 0x66, 0x0, 0x67, 0x0, 0x68, 0x0, 0x69, 0x0, 0x6a, 0x0, 0x6b, 0x0, 0x6c, 0x0, 0x6d, 0x0, 0x6e, 0x0, 0x6f, 0x0, 0x70, 0x0, 0x71, 0x0, 0x72, 0x0, 0x73, 0x0, 0x74, 0x0, 0x75, 0x0, 0x76, 0x0, 0x77, 0x0, 0x78, 0x0, 0x79, 0x0, 0x7a, 0x0,
+	// A-Z
+	0x41, 0x0, 0x42, 0x0, 0x43, 0x0, 0x44, 0x0, 0x45, 0x0, 0x46, 0x0, 0x47, 0x0, 0x48, 0x0, 0x49, 0x0, 0x4a, 0x0, 0x4b, 0x0, 0x4c, 0x0, 0x4d, 0x0, 0x4e, 0x0, 0x4f, 0x0, 0x50, 0x0, 0x51, 0x0, 0x52, 0x0, 0x53, 0x0, 0x54, 0x0, 0x55, 0x0, 0x56, 0x0, 0x57, 0x0, 0x58, 0x0, 0x59, 0x0, 0x5a, 0x0,
+}
+var decodedLongASCIIString string = "123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// multiple copies of the above
+var encodedLongerASCIIBytes []byte
+var decodedLongerASCIIString string
+
+var encodedUnicode1 = []byte{0x61, 0x0, 0x62, 0x0, 0x63, 0x0, 0x64, 0x0, 0x65, 0x0, 0x66, 0x0, 0x67, 0x0, 0x68, 0x0, 0x69, 0x0, 0x6a, 0x1}
+var encodedUnicode2 = []byte{0x61, 0x0, 0x62, 0x0, 0x63, 0x0, 0x64, 0x0, 0x65, 0x0, 0x66, 0x0, 0x67, 0x0, 0x68, 0x0, 0x69, 0x0, 0x6a, 0x0, 0x6b, 0x0, 0x6c, 0x0, 0x6d, 0x1}
+var encodedUnicode3 = []byte{0x61, 0x0, 0x62, 0x0, 0x63, 0x0, 0x64, 0x0, 0x65, 0x0, 0x66, 0x0, 0x67, 0x0, 0x68, 0x0, 0x69, 0x0, 0x6a, 0x0, 0x6b, 0x0, 0x6c, 0x0, 0x6d, 0x1, 0x1, 0x1}
+var encodedASCIIWithTrailingUnicode = []byte{0x61, 0x0, 0x62, 0x0, 0x63, 0x0, 0x64, 0x0, 0x65, 0x0, 0x66, 0x0, 0x67, 0x0, 0x68, 0x0, 0x69, 0x0, 0x6a, 0x0, 0x6b, 0x0, 0x6c, 0x0, 0x6d, 0x0, 0x6e, 0x0, 0x6f, 0x0, 0x7e, 0x76, 0x70, 0x0}
+var stringASCIIWithTrailingUnicode = "abcdefghijklmno百p"
+var encodedEmoji = []byte{0xF0, 0x9F, 0x98, 0x8B}
+var stringEmoji = "😋"
+var longEmoji = "😀😃😄😁😆😅🤣😂🙂🙃😉😊😇😍🤩😘😗"
+var longEmojiBytes []byte
+var encodedASCIIWithTrailingUnicode2 []byte
+
+// create various test strings and byte slices for the ucs22str function
+func init() {
+
+	uint16s := utf16.Encode([]rune(longEmoji))
+
+	longEmojiBytes = make([]byte, len(uint16s)*2)
+
+	for i := 0; i < len(uint16s); i++ {
+		longEmojiBytes[i*2] = byte(uint16s[i] & 0xFF)
+		longEmojiBytes[(i*2)+1] = byte((uint16s[i] >> 8) & 0xFF)
+	}
+
+	uint16s = utf16.Encode([]rune(stringASCIIWithTrailingUnicode))
+
+	encodedASCIIWithTrailingUnicode2 = make([]byte, len(uint16s)*2)
+
+	for i := 0; i < len(uint16s); i++ {
+		encodedASCIIWithTrailingUnicode2[i*2] = byte(uint16s[i] & 0xFF)
+		encodedASCIIWithTrailingUnicode2[(i*2)+1] = byte((uint16s[i] >> 8) & 0xFF)
+	}
+
+	equal := bytes.Compare(encodedASCIIWithTrailingUnicode, encodedASCIIWithTrailingUnicode2)
+
+	if equal != 0 {
+		fmt.Print("Expected array to equal.")
+	}
+
+	for i := 0; i < 10; i++ {
+		encodedLongerASCIIBytes = append(encodedLongerASCIIBytes, encodedLongASCIIBytes...)
+		decodedLongerASCIIString = decodedLongerASCIIString + decodedLongASCIIString
+	}
+}
+
+func ExerciseUCS2ToStringFunction(name string, sut func([]byte) (string, error), t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{"Ascii 1", encoded1Bytes, "1"},
+		{"Ascii 2", encoded12Bytes, "12"},
+		{"Ascii 3", encoded123Bytes, "123"},
+		{"Ascii 4", encoded1234Bytes, "1234"},
+		{"Ascii 5", encoded12345Bytes, "12345"},
+		{"Ascii 6", encoded123456Bytes, "123456"},
+		{"Ascii 7", encoded1234567Bytes, "1234567"},
+		{"Ascii 8", encoded12345678Bytes, "12345678"},
+		{"Ascii 9", encoded123456789Bytes, "123456789"},
+		{"Long Ascii", encodedLongASCIIBytes, decodedLongASCIIString},
+		{"Longer Ascii", encodedLongerASCIIBytes, decodedLongerASCIIString},
+		{"Random Unicode1", encodedUnicode1, "abcdefghiŪ"},
+		{"Random Unicode2", encodedUnicode2, "abcdefghijklŭ"},
+		{"Random Unicode3", encodedUnicode3, "abcdefghijklŭā"},
+		{"TrailingUnicode", encodedASCIIWithTrailingUnicode, stringASCIIWithTrailingUnicode},
+		{"LongEmoji", longEmojiBytes, longEmoji},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual, err := sut(tt.input)
+
+			if err != nil {
+				t.Errorf("%s errored: %s", name, err)
+			}
+
+			if actual != tt.expected {
+				t.Errorf("%s expected to return %s but it returned %s", name, tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUcs22str(t *testing.T) {
+	ExerciseUCS2ToStringFunction("ucs22str", ucs22str, t)
+}
+
+var sideeffect_varchar string
+
+//ucs22str benchmarks
+func BenchmarkUcs22strAscii(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		s, _ := ucs22str(encoded123Bytes)
+		sideeffect_varchar = s
+	}
+}
+
+func BenchmarkUcs22strMediumAscii(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		s, _ := ucs22str(encoded123456789Bytes)
+		sideeffect_varchar = s
+	}
+}
+
+func BenchmarkUcs22strLongAscii(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		s, _ := ucs22str(encodedLongASCIIBytes)
+		sideeffect_varchar = s
+	}
+}
+
+func BenchmarkUcs22strLongerAscii(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		s, _ := ucs22str(encodedLongerASCIIBytes)
+		sideeffect_varchar = s
+	}
+}
+
+func BenchmarkUcs22strTrailingUnicode(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		s, _ := ucs22str(encodedASCIIWithTrailingUnicode)
+		sideeffect_varchar = s
+	}
+}
+
+func BenchmarkUcs22strLongEmojis(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		s, _ := ucs22str(longEmojiBytes)
+		sideeffect_varchar = s
 	}
 }
 


### PR DESCRIPTION
This pull request covers some changes to improve performance in the tdsBuffer struct and ucs22str function.

buf.go
The tdsBuffer uint16 function is used heavily throughout the tds parsing code. The original implementation created a byte array and a slice 
into it to be filled by a call to ReadFull. This calls through io.ReadFull back into tdsBuffer io.Reader Read function. This code path incurs
significant overhead when the buffer already has at least 2 bytes available. The new implementation checks the read position before calling
ReadFull. If we have at least two bytes available we read directly, otherwise fall back to the slow path. 
uint32 and uint64 have also been changed in the same way for 4 & 8 byte reads.

uint16 - a loop calling uint16 10000 times
BenchmarkReadUint16Implementations/reference-12                  4010	304633 ns/op    20045 B/op       10001 allocs/op
BenchmarkReadUint16Implementations/new_version-12                23412	50691 ns/op		32 B/op              1 allocs/op

uint32 - a loop calling uint32 5000 times
BenchmarkReadUint32Implementations/reference-12                  6684	154147 ns/op    20045 B/op        5001 allocs/op
BenchmarkReadUint32Implementations/new_version-12                48321	25327 ns/op		32 B/op              1 allocs/op

uint64 - a loop calling uint64 2500 times
BenchmarkReadUint64Implementations/reference-12                  3795	87688 ns/op		20045 B/op        2501 allocs/op
BenchmarkReadUint64Implementations/new_version-12                85941	14582 ns/op		32 B/op              1 allocs/op

tds.go - performance improvement on ucs22str function. It is responsible for reading 16bit ucs2 characters and producing a string.
Most of the strings we deal with are ascii so the full unicode handling path can be bypassed when they are found. We use unsafe to read the incoming bytes
in 8 byte chunks, as uint64s, masking the value to find invalid ascii. If found we fall back to a faster version of the original 
implementation to deal with the unicode. Otherwise we have 8 bytes and 4 can be safely added to the output buffer. If we reach the end of the input 
successfully the buffer can be converted directly to a string. This reduces allocations on the ascii path and is a significant speed improvement, up to 16x in our tests. 
The faster unicode path avoids copying the byte data to a newly allocated uint16 array. It again uses unsafe, to create a uint16 slice to the original byte data. 
This is safe because it is passed to directly utf16.Decode, which itself creates a copy as a []rune. This saves us an allocation, copying and uint16 conversion.

Reference Implementation
BenchmarkUcs22strReferenceAscii-12                      12274105              98.6 ns/op              32 B/op          3 allocs/op
BenchmarkUcs22strReferenceMediumAscii-12                 6721837               178 ns/op              96 B/op          3 allocs/op
BenchmarkUcs22strReferenceLongAscii-12                   1538629               778 ns/op             448 B/op          3 allocs/op
BenchmarkUcs22strReferenceLongerAscii-12                  169466              7115 ns/op            4608 B/op          3 allocs/op
BenchmarkUcs22strReferenceTrailingUnicode-12             4423173               274 ns/op             160 B/op          3 allocs/op
BenchmarkUcs22strReferenceLongEmojis-12                  3166297               380 ns/op             304 B/op          3 allocs/op

New Implementation
BenchmarkUcs22strAscii-12                               54690384                21.9 ns/op             3 B/op          1 allocs/op
BenchmarkUcs22strMediumAscii-12                         35389251                33.4 ns/op            16 B/op          1 allocs/op
BenchmarkUcs22strLongAscii-12                           17188800                70.1 ns/op            64 B/op          1 allocs/op
BenchmarkUcs22strLongerAscii-12                          2864568                 427 ns/op           640 B/op          1 allocs/op
BenchmarkUcs22strTrailingUnicode-12                      4221280                 259 ns/op           144 B/op          3 allocs/op
BenchmarkUcs22strLongEmojis-12                           3549286                 341 ns/op           272 B/op          3 allocs/op

buf.go
A tdsBuffer is created for each sql connection and internally holds two []byte buffers, one for reading and one for writing. They are allocated directly with 
make. Each time a connection is closed, they are garbage collected. We added a sync.Pool managed pool of 64k []byte slices. These are created as required and
placed back in the pool when the tdsBuffer is closed. Each pooled slice is used for the read and write buffers by reslicing half for each.
Connections are generally long lived so this is a minor improvement to garbage collection overhead at the expense of slightly increased memory usage. Happy to discuss this further if you deem it not required.

All benchmarks done on an 8core i7, 16gb