### PR TITLE
Export auth interface to allow external implementations e.g. krb5

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,30 @@
+package mssql
+
+import (
+	"github.com/denisenkom/go-mssqldb/auth"
+	"github.com/denisenkom/go-mssqldb/auth/ntlm"
+)
+
+var (
+	// this instance will be used if one is provided via a call to SetAuthProvider.
+	authProvider auth.Provider
+	// this is the default implementation to be used when no override is provided by
+	// the application. This default is itself overridden to use Windows SSPI in auth_windows.go
+	defaultAuthProvider = ntlm.AuthProvider
+)
+
+// getAuth calls the authProvider GetAuth if set, otherwise fails back to the
+// defaultAuthProvider GetAuth.
+func getAuth(user, password, service, workstation string) (auth.Auth, bool) {
+	if authProvider != nil {
+		return authProvider.GetAuth(user, password, service, workstation)
+	}
+
+	return defaultAuthProvider.GetAuth(user, password, service, workstation)
+}
+
+// SetAuthProvider allows overriding of the authentication provider used. It should be called before any connections
+// are created.
+func SetAuthProvider(p auth.Provider) {
+	authProvider = p
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,21 @@
+package auth
+
+// Provider is an SSPI compatible authentication provider
+type Provider interface {
+	// GetAuth is responsible for returning an instance of the required Auth interface
+	GetAuth(user, password, service, workstation string) (Auth, bool)
+}
+
+// Auth is the interface for SSPI Login Authentication providers
+type Auth interface {
+	InitialBytes() ([]byte, error)
+	NextBytes([]byte) ([]byte, error)
+	Free()
+}
+
+// ProviderFunc is an adapter to convert a GetAuth func into a Provider
+type ProviderFunc func(user, password, service, workstation string) (Auth, bool)
+
+func (f ProviderFunc) GetAuth(user, password, service, workstation string) (Auth, bool) {
+	return f(user, password, service, workstation)
+}

--- a/auth/ntlm/ntlm.go
+++ b/auth/ntlm/ntlm.go
@@ -129,18 +129,6 @@ func createDesKey(bytes, material []byte) {
 	material[7] = (byte)(bytes[6] << 1)
 }
 
-func oddParity(bytes []byte) {
-	for i := 0; i < len(bytes); i++ {
-		b := bytes[i]
-		needsParity := (((b >> 7) ^ (b >> 6) ^ (b >> 5) ^ (b >> 4) ^ (b >> 3) ^ (b >> 2) ^ (b >> 1)) & 0x01) == 0
-		if needsParity {
-			bytes[i] = bytes[i] | byte(0x01)
-		} else {
-			bytes[i] = bytes[i] & byte(0xfe)
-		}
-	}
-}
-
 func encryptDes(key []byte, cleartext []byte, ciphertext []byte) {
 	var desKey [8]byte
 	createDesKey(key, desKey[:])

--- a/auth/ntlm/ntlm.go
+++ b/auth/ntlm/ntlm.go
@@ -1,6 +1,4 @@
-// +build !windows
-
-package mssql
+package ntlm
 
 import (
 	"crypto/des"
@@ -13,6 +11,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf16"
+
+	"github.com/denisenkom/go-mssqldb/auth"
 
 	//lint:ignore SA1019 MD4 is used by legacy NTLM
 	"golang.org/x/crypto/md4"
@@ -56,19 +56,21 @@ const _NEGOTIATE_FLAGS = _NEGOTIATE_UNICODE |
 	_NEGOTIATE_ALWAYS_SIGN |
 	_NEGOTIATE_EXTENDED_SESSIONSECURITY
 
-type ntlmAuth struct {
+type Auth struct {
 	Domain      string
 	UserName    string
 	Password    string
 	Workstation string
 }
 
-func getAuth(user, password, service, workstation string) (auth, bool) {
+// getAuth returns an authentication handle Auth to provide authentication content
+// to mssql.connect
+func getAuth(user, password, service, workstation string) (auth.Auth, bool) {
 	if !strings.ContainsRune(user, '\\') {
 		return nil, false
 	}
 	domain_user := strings.SplitN(user, "\\", 2)
-	return &ntlmAuth{
+	return &Auth{
 		Domain:      domain_user[0],
 		UserName:    domain_user[1],
 		Password:    password,
@@ -90,7 +92,7 @@ func utf16le(val string) []byte {
 	return v
 }
 
-func (auth *ntlmAuth) InitialBytes() ([]byte, error) {
+func (auth *Auth) InitialBytes() ([]byte, error) {
 	domain_len := len(auth.Domain)
 	workstation_len := len(auth.Workstation)
 	msg := make([]byte, 40+domain_len+workstation_len)
@@ -125,6 +127,18 @@ func createDesKey(bytes, material []byte) {
 	material[5] = (byte)(bytes[4]<<3 | (bytes[5]&0xff)>>5)
 	material[6] = (byte)(bytes[5]<<2 | (bytes[6]&0xff)>>6)
 	material[7] = (byte)(bytes[6] << 1)
+}
+
+func oddParity(bytes []byte) {
+	for i := 0; i < len(bytes); i++ {
+		b := bytes[i]
+		needsParity := (((b >> 7) ^ (b >> 6) ^ (b >> 5) ^ (b >> 4) ^ (b >> 3) ^ (b >> 2) ^ (b >> 1)) & 0x01) == 0
+		if needsParity {
+			bytes[i] = bytes[i] | byte(0x01)
+		} else {
+			bytes[i] = bytes[i] & byte(0xfe)
+		}
+	}
 }
 
 func encryptDes(key []byte, cleartext []byte, ciphertext []byte) {
@@ -358,7 +372,7 @@ func buildNTLMResponsePayload(lm, nt []byte, flags uint32, domain, workstation, 
 	return msg, nil
 }
 
-func (auth *ntlmAuth) NextBytes(bytes []byte) ([]byte, error) {
+func (auth *Auth) NextBytes(bytes []byte) ([]byte, error) {
 	signature := string(bytes[0:8])
 	if signature != "NTLMSSP\x00" {
 		return nil, errorNTLM
@@ -389,5 +403,5 @@ func (auth *ntlmAuth) NextBytes(bytes []byte) ([]byte, error) {
 	return buildNTLMResponsePayload(lm, nt, flags, auth.Domain, auth.Workstation, auth.UserName)
 }
 
-func (auth *ntlmAuth) Free() {
+func (auth *Auth) Free() {
 }

--- a/auth/ntlm/ntlm_test.go
+++ b/auth/ntlm/ntlm_test.go
@@ -1,6 +1,4 @@
-// +build !windows
-
-package mssql
+package ntlm
 
 import (
 	"bytes"
@@ -94,11 +92,11 @@ func TestNTLMV2Response(t *testing.T) {
 	expectedNTLMV2Response, _ := hex.DecodeString("5c788afec59c1fef3f90bf6ea419c02501010000000000000fc4a4d5fdf6b200ffffff00112233440000000002000c0044004f004d00410049004e0001000c005300450052005600450052000400140064006f006d00610069006e002e0063006f006d00030022007300650072007600650072002e0064006f006d00610069006e002e0063006f006d000000000000000000")
 	expectedLMV2Response, _ := hex.DecodeString("d6e6152ea25d03b7c6ba6629c2d6aaf0ffffff0011223344")
 	ntlmV2Response, lmV2Response := getNTLMv2AndLMv2ResponsePayloads(target, username, password, challenge, nonce, targetInformationBlock, timestamp)
-	if !bytes.Equal(ntlmV2Response, expectedNTLMV2Response) {
+	if bytes.Compare(ntlmV2Response, expectedNTLMV2Response) != 0 {
 		t.Errorf("got:\n%s\nexpected:\n%s", hex.Dump(ntlmV2Response), hex.Dump(expectedNTLMV2Response))
 	}
 
-	if !bytes.Equal(lmV2Response, expectedLMV2Response) {
+	if bytes.Compare(lmV2Response, expectedLMV2Response) != 0 {
 		t.Errorf("got:\n%s\nexpected:\n%s", hex.Dump(ntlmV2Response), hex.Dump(expectedNTLMV2Response))
 	}
 }

--- a/auth/ntlm/ntlm_test.go
+++ b/auth/ntlm/ntlm_test.go
@@ -92,11 +92,11 @@ func TestNTLMV2Response(t *testing.T) {
 	expectedNTLMV2Response, _ := hex.DecodeString("5c788afec59c1fef3f90bf6ea419c02501010000000000000fc4a4d5fdf6b200ffffff00112233440000000002000c0044004f004d00410049004e0001000c005300450052005600450052000400140064006f006d00610069006e002e0063006f006d00030022007300650072007600650072002e0064006f006d00610069006e002e0063006f006d000000000000000000")
 	expectedLMV2Response, _ := hex.DecodeString("d6e6152ea25d03b7c6ba6629c2d6aaf0ffffff0011223344")
 	ntlmV2Response, lmV2Response := getNTLMv2AndLMv2ResponsePayloads(target, username, password, challenge, nonce, targetInformationBlock, timestamp)
-	if bytes.Compare(ntlmV2Response, expectedNTLMV2Response) != 0 {
+	if !bytes.Equal(ntlmV2Response, expectedNTLMV2Response) {
 		t.Errorf("got:\n%s\nexpected:\n%s", hex.Dump(ntlmV2Response), hex.Dump(expectedNTLMV2Response))
 	}
 
-	if bytes.Compare(lmV2Response, expectedLMV2Response) != 0 {
+	if !bytes.Equal(lmV2Response, expectedLMV2Response) {
 		t.Errorf("got:\n%s\nexpected:\n%s", hex.Dump(ntlmV2Response), hex.Dump(expectedNTLMV2Response))
 	}
 }

--- a/auth/ntlm/provider.go
+++ b/auth/ntlm/provider.go
@@ -1,0 +1,6 @@
+package ntlm
+
+import "github.com/denisenkom/go-mssqldb/auth"
+
+// AuthProvider handles NTLM SSPI Windows Authentication
+var AuthProvider auth.Provider = auth.ProviderFunc(getAuth)

--- a/auth/winsspi/provider.go
+++ b/auth/winsspi/provider.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package winsspi
+
+import "github.com/denisenkom/go-mssqldb/auth"
+
+// AuthProvider handles SSPI Windows Authentication via secur32.dll functions
+var AuthProvider auth.Provider = auth.ProviderFunc(getAuth)

--- a/auth/winsspi/winsspi.go
+++ b/auth/winsspi/winsspi.go
@@ -1,10 +1,14 @@
-package mssql
+// +build windows
+
+package winsspi
 
 import (
 	"fmt"
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/denisenkom/go-mssqldb/auth"
 )
 
 var (
@@ -104,7 +108,7 @@ type SecBufferDesc struct {
 	pBuffers  *SecBuffer
 }
 
-type SSPIAuth struct {
+type Auth struct {
 	Domain   string
 	UserName string
 	Password string
@@ -113,15 +117,17 @@ type SSPIAuth struct {
 	ctxt     SecHandle
 }
 
-func getAuth(user, password, service, workstation string) (auth, bool) {
+// getAuth returns an authentication handle Auth to provide authentication content
+// to mssql.connect
+func getAuth(user, password, service, workstation string) (auth.Auth, bool) {
 	if user == "" {
-		return &SSPIAuth{Service: service}, true
+		return &Auth{Service: service}, true
 	}
 	if !strings.ContainsRune(user, '\\') {
 		return nil, false
 	}
 	domain_user := strings.SplitN(user, "\\", 2)
-	return &SSPIAuth{
+	return &Auth{
 		Domain:   domain_user[0],
 		UserName: domain_user[1],
 		Password: password,
@@ -129,7 +135,7 @@ func getAuth(user, password, service, workstation string) (auth, bool) {
 	}, true
 }
 
-func (auth *SSPIAuth) InitialBytes() ([]byte, error) {
+func (auth *Auth) InitialBytes() ([]byte, error) {
 	var identity *SEC_WINNT_AUTH_IDENTITY
 	if auth.UserName != "" {
 		identity = &SEC_WINNT_AUTH_IDENTITY{
@@ -202,7 +208,7 @@ func (auth *SSPIAuth) InitialBytes() ([]byte, error) {
 	return outbuf[:buf.cbBuffer], nil
 }
 
-func (auth *SSPIAuth) NextBytes(bytes []byte) ([]byte, error) {
+func (auth *Auth) NextBytes(bytes []byte) ([]byte, error) {
 	var in_buf, out_buf SecBuffer
 	var in_desc, out_desc SecBufferDesc
 
@@ -254,7 +260,7 @@ func (auth *SSPIAuth) NextBytes(bytes []byte) ([]byte, error) {
 	return outbuf[:out_buf.cbBuffer], nil
 }
 
-func (auth *SSPIAuth) Free() {
+func (auth *Auth) Free() {
 	syscall.Syscall6(sec_fn.DeleteSecurityContext,
 		1,
 		uintptr(unsafe.Pointer(&auth.ctxt)),

--- a/auth_windows.go
+++ b/auth_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package mssql
+
+import "github.com/denisenkom/go-mssqldb/auth/winsspi"
+
+func init() {
+	defaultAuthProvider = winsspi.AuthProvider
+}

--- a/tds.go
+++ b/tds.go
@@ -16,6 +16,7 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
+	"github.com/denisenkom/go-mssqldb/auth"
 	"github.com/denisenkom/go-mssqldb/msdsn"
 )
 
@@ -841,12 +842,6 @@ func sendAttention(buf *tdsBuffer) error {
 	return buf.FinishPacket()
 }
 
-type auth interface {
-	InitialBytes() ([]byte, error)
-	NextBytes([]byte) ([]byte, error)
-	Free()
-}
-
 // SQL Server AlwaysOn Availability Group Listeners are bound by DNS to a
 // list of IP addresses.  So if there is more than one, try them all and
 // use the first one that allows a connection.
@@ -971,7 +966,7 @@ func interpretPreloginResponse(p msdsn.Config, fe *featureExtFedAuth, fields map
 	return
 }
 
-func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, logger ContextLogger, auth auth, fe *featureExtFedAuth, packetSize uint32) (l *login, err error) {
+func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, logger ContextLogger, auth auth.Auth, fe *featureExtFedAuth, packetSize uint32) (l *login, err error) {
 	var typeFlags uint8
 	if p.ReadOnlyIntent {
 		typeFlags |= fReadOnlyIntent


### PR DESCRIPTION
The original driver auth interface and implementations have been moved into their own packages and exported. There are two implementations within the driver, NTLM and Windows SSPI.
As before the default on windows is the winsspi package and NTLM on Linux.

The consuming application can now override this at runtime by calling `mssql.SetAuthProvider(authProvider)` e.g.

``` golang
// create a new auth.Provider around the kerberos client
provider := krb5.NewAuthProvider(krbClient)

// pass the provider to mssql to override the default authentication mechanism
mssql.SetAuthProvider(provider)
```

We have created an `auth.Provider` implementation here https://github.com/bet365/go-mssqldb-auth-krb5 which uses http://github.com/jcmturner/gokrb5 to authenticate with active directory. 

This keep the main driver free from the krb5 dependency and opens the possibility for other implementations in future.

If this pull request is accepted we will update our implementation to the main repo master. Currently it is using a replacement to point at a branch. 

We are aware of #702 but have been using the go-mssqldb driver in production since last year with this kerberos integration change and wanted to offer an alternative and are happy to discuss approach or changes. Thanks again for the excellent work.

