### PR TITLE
Connect to a DB by directly supplying auth token

### DIFF
--- a/azuread/configuration.go
+++ b/azuread/configuration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
 	mssql "github.com/denisenkom/go-mssqldb"
 	"github.com/denisenkom/go-mssqldb/msdsn"
 )
@@ -22,9 +23,10 @@ const (
 	ActiveDirectoryMSI             = "ActiveDirectoryMSI"
 	ActiveDirectoryManagedIdentity = "ActiveDirectoryManagedIdentity"
 	// ActiveDirectoryApplication is a synonym for ActiveDirectoryServicePrincipal
-	ActiveDirectoryApplication      = "ActiveDirectoryApplication"
-	ActiveDirectoryServicePrincipal = "ActiveDirectoryServicePrincipal"
-	scopeDefaultSuffix              = "/.default"
+	ActiveDirectoryApplication               = "ActiveDirectoryApplication"
+	ActiveDirectoryServicePrincipal          = "ActiveDirectoryServicePrincipal"
+	ActiveDirectoryServicePrincipalAuthToken = "ActiveDirectoryServicePrincipalAuthToken"
+	scopeDefaultSuffix                       = "/.default"
 )
 
 type azureFedAuthConfig struct {
@@ -120,7 +122,14 @@ func (p *azureFedAuthConfig) validateParameters(params map[string]string) error 
 		p.user, _ = params["user id"]
 		// we don't really have a password but we need to use some value.
 		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryServicePrincipalAuthToken):
+		p.fedAuthLibrary = mssql.FedAuthLibrarySecurityToken
+		p.adalWorkflow = mssql.FedAuthADALWorkflowNone
+		p.password, _ = params["password"]
 
+		if p.password == "" {
+			return errors.New("Must provide 'password' parameter when using ActiveDirectoryApplicationAuthToken authentication")
+		}
 	default:
 		return fmt.Errorf("Invalid federated authentication type '%s': expected one of %+v",
 			fedAuthWorkflow,
@@ -168,6 +177,8 @@ func (p *azureFedAuthConfig) provideActiveDirectoryToken(ctx context.Context, se
 		default:
 			cred, err = azidentity.NewClientSecretCredential(tenant, p.clientID, p.clientSecret, nil)
 		}
+	case ActiveDirectoryServicePrincipalAuthToken:
+		return p.password, nil
 	case ActiveDirectoryPassword:
 		cred, err = azidentity.NewUsernamePasswordCredential(tenant, p.applicationClientID, p.user, p.password, nil)
 	case ActiveDirectoryMSI, ActiveDirectoryManagedIdentity:

--- a/azuread/configuration_test.go
+++ b/azuread/configuration_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestValidateParameters(t *testing.T) {
 	passphrase := "somesecret"
+	authToken := "some-auth-token"
 	certificatepath := "/user/cert/cert.pfx"
 	appid := "applicationclientid=someguid"
 	certprop := "clientcertpath=" + certificatepath
@@ -88,6 +89,15 @@ func TestValidateParameters(t *testing.T) {
 				fedAuthWorkflow: ActiveDirectoryManagedIdentity,
 			},
 		},
+		{
+			name: "application with auth token",
+			dsn:  "server=someserver.database.windows.net;fedauth=ActiveDirectoryServicePrincipalAuthToken;password=some-auth-token;",
+			expected: &azureFedAuthConfig{
+				password:    authToken,
+				adalWorkflow:    mssql.FedAuthADALWorkflowNone,
+				fedAuthWorkflow: ActiveDirectoryServicePrincipalAuthToken,
+			},
+		},
 	}
 	for _, tst := range tests {
 		config, err := parse(tst.dsn)
@@ -109,7 +119,7 @@ func TestValidateParameters(t *testing.T) {
 		// mssqlConfig is not idempotent due to pointers in it, plus we aren't testing its correctness here
 		config.mssqlConfig = msdsn.Config{}
 		if *config != *tst.expected {
-			t.Errorf("Captured parameters do not match in test case '%s'. Expected:%+v, Actual:%+v", tst.name, tst.expected, config)
+			t.Errorf("Captured parameters do not match in test case '%s'. \nExpected:%+v, \nActual:%+v", tst.name, tst.expected, config)
 		}
 	}
 

--- a/examples/azuread-service-principal-authtoken/service_principal_authtoken.go
+++ b/examples/azuread-service-principal-authtoken/service_principal_authtoken.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+
+	_ "github.com/denisenkom/go-mssqldb"
+	"github.com/denisenkom/go-mssqldb/azuread"
+)
+
+var (
+	debug         = flag.Bool("debug", true, "enable debugging")
+	password      = flag.String("password", "", "the client secret for the app/client ID")
+	port     *int = flag.Int("port", 1433, "the database port")
+	server        = flag.String("server", "", "the database server")
+	database      = flag.String("database", "", "the database name")
+)
+
+func main() {
+	flag.Parse()
+
+	if *debug {
+		fmt.Printf(" password:%s\n", *password)
+		fmt.Printf(" port:%d\n", *port)
+		fmt.Printf(" server:%s\n", *server)
+		fmt.Printf(" database:%s\n", *database)
+	}
+
+	connString := fmt.Sprintf("server=%s;password=%s;port=%d;database=%s;fedauth=ActiveDirectoryServicePrincipalAuthToken;", *server, *password, *port, *database)
+	if *debug {
+		fmt.Printf(" connString:%s\n", connString)
+	}
+	conn, err := sql.Open(azuread.DriverName, connString)
+	if err != nil {
+		log.Fatal("Open connection failed:", err.Error())
+	}
+	defer conn.Close()
+
+	stmt, err := conn.Prepare("select 1, 'abc'")
+	if err != nil {
+		log.Fatal("Prepare failed:", err.Error())
+	}
+	defer stmt.Close()
+
+	row := stmt.QueryRow()
+	var somenumber int64
+	var somechars string
+	err = row.Scan(&somenumber, &somechars)
+	if err != nil {
+		log.Fatal("Scan failed:", err.Error())
+	}
+	fmt.Printf("somenumber:%d\n", somenumber)
+	fmt.Printf("somechars:%s\n", somechars)
+
+	fmt.Printf("bye\n")
+}

--- a/fedauth.go
+++ b/fedauth.go
@@ -34,6 +34,9 @@ const (
 
 	// FedAuthADALWorkflowMSI uses the managed identity service to obtain a token
 	FedAuthADALWorkflowMSI = 0x03
+
+	// FedAuthADALWorkflowNone does not need to obtain token
+	FedAuthADALWorkflowNone = 0x04
 )
 
 // newSecurityTokenConnector creates a new connector from a Config and a token provider.


### PR DESCRIPTION
Refer to the example file (examples/azuread-service-principal-authtoken/service_principal_authtoken.go) to understand how it will work.

CRLF difference is causing all the lines to be shown as changed, not sure if GitHub offers an option to ignore this while reviewing, suggestions are welcome.

Fixes #752.