### PR TITLE
Resolving type conversion errors

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -335,6 +335,8 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 			intvalue = int64(val)
 		case float64:
 			intvalue = int64(val)
+		case string:
+			intvalue, _ = strconv.ParseInt(val, 10, 64)
 		default:
 			err = fmt.Errorf("mssql: invalid type for int column: %T", val)
 			return
@@ -362,6 +364,8 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 			floatvalue = float64(val)
 		case int64:
 			floatvalue = float64(val)
+		case string:
+			floatvalue, _ = strconv.ParseFloat(val, 64)
 		default:
 			err = fmt.Errorf("mssql: invalid type for float column: %T %s", val, val)
 			return

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -408,16 +408,24 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 		res.ti.Size = len(res.buffer)
 
 	case typeBit, typeBitN:
-		if reflect.TypeOf(val).Kind() != reflect.Bool {
-			err = fmt.Errorf("mssql: invalid type for bit column: %T %s", val, val)
-			return
+		var boolvalue bool
+		switch val := val.(type) {
+		case string:
+			boolvalue, _ = strconv.ParseBool(val)
+		case bool:
+			boolvalue = val
+		default:
+			if reflect.TypeOf(val).Kind() != reflect.Bool {
+				err = fmt.Errorf("mssql: invalid type for bit column: %T %s", val, val)
+				return
+			}
+		}
+		res.buffer = make([]byte, 1)
+		if boolvalue {
+			res.buffer[0] = 1
 		}
 		res.ti.TypeId = typeBitN
 		res.ti.Size = 1
-		res.buffer = make([]byte, 1)
-		if val.(bool) {
-			res.buffer[0] = 1
-		}
 	case typeDateTime2N:
 		switch val := val.(type) {
 		case time.Time:


### PR DESCRIPTION
When I try to import the string "1" into the int column of the database, I always get a type conversion error, which should be allowed.